### PR TITLE
Fix long path handling in offline package build and installer

### DIFF
--- a/installer/CodexOffline.iss.tpl
+++ b/installer/CodexOffline.iss.tpl
@@ -22,6 +22,7 @@ UninstallDisplayIcon={app}\_internal\app\Codex.exe
 ArchitecturesAllowed=x64compatible
 ArchitecturesInstallIn64BitMode=x64compatible
 PrivilegesRequired=lowest
+UseLongPathAware=yes
 
 [Files]
 Source: "{#MySourceRoot}\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs

--- a/scripts/build-offline-package.ps1
+++ b/scripts/build-offline-package.ps1
@@ -785,6 +785,10 @@ $encodedCuaNodeRepairs = Repair-EncodedScopedNodeModules -RootPath (Join-Path $i
 if (@($encodedCuaNodeRepairs).Count -gt 0) {
     Write-BuildTrace "Repaired encoded scoped node_modules in cua_node ($(@($encodedCuaNodeRepairs).Count))."
 }
+$encodedAsarUnpackedRepairs = Repair-EncodedScopedNodeModules -RootPath (Join-Path $internalRoot 'app/resources/app.asar.unpacked')
+if (@($encodedAsarUnpackedRepairs).Count -gt 0) {
+    Write-BuildTrace "Repaired encoded scoped node_modules in app.asar.unpacked ($(@($encodedAsarUnpackedRepairs).Count))."
+}
 $computerUseClientRepairs = Repair-ComputerUseClientNativePipeFallback -RootPath (Join-Path $internalRoot 'app/resources/plugins/openai-bundled/plugins/computer-use')
 if (@($computerUseClientRepairs).Count -gt 0) {
     Write-BuildTrace "Repaired Computer Use native pipe fallback ($(@($computerUseClientRepairs).Count))."


### PR DESCRIPTION
## Summary
This PR addresses long path handling issues in the offline package build process and installer configuration.

## Key Changes
- **Build Script**: Added repair logic for encoded scoped node_modules in the `app.asar.unpacked` directory, mirroring the existing repair process for `cua_node`. This ensures that any path encoding issues in unpacked ASAR resources are properly corrected during the build.
- **Installer Configuration**: Enabled `UseLongPathAware=yes` in the Inno Setup installer template to properly support Windows long path names (paths exceeding 260 characters), which is necessary for the offline package that contains deeply nested node_modules directories.

## Implementation Details
The build script change applies the same `Repair-EncodedScopedNodeModules` function to the unpacked ASAR resources that was already being used for the CUA node modules, ensuring consistent handling of encoded paths across all node_modules locations in the package.

The installer change enables long path awareness at the system level, allowing the installation process to handle the complex directory structures without path length limitations.

https://claude.ai/code/session_019k2tb7Y5Z4YgBJxhMM7643