### PR TITLE
fix(installer): remove invalid UseLongPathAware Inno Setup directive

### DIFF
--- a/installer/CodexOffline.iss.tpl
+++ b/installer/CodexOffline.iss.tpl
@@ -22,7 +22,6 @@ UninstallDisplayIcon={app}\_internal\app\Codex.exe
 ArchitecturesAllowed=x64compatible
 ArchitecturesInstallIn64BitMode=x64compatible
 PrivilegesRequired=lowest
-UseLongPathAware=yes
 
 [Files]
 Source: "{#MySourceRoot}\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs


### PR DESCRIPTION
## Summary
- Remove `UseLongPathAware=yes` from `installer/CodexOffline.iss.tpl` — it is not a valid Inno Setup 6.x `[Setup]` directive
- CI (Inno Setup 6.7.1) fails with `Unrecognized [Setup] section directive "UseLongPathAware"` causing the installer to not be generated, which then fails the verify step (`RequireInstallerAsset`)
- The short `WorkRoot` (`D:\cb`) already avoids MAX_PATH issues during CI builds

## Context
Introduced in #63 (`d716775`). The PR build itself failed with this same error, but was merged anyway. The subsequent push-to-main build is also failing.

## Test plan
- [x] Local build succeeds (`build-offline-package.ps1`)
- [x] Local verify passes (`verify-offline-package.ps1`) including desktop direct-launch smoke test
- [ ] CI build passes with Inno Setup 6.7.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)