### PR TITLE
fix(installer): remove invalid UseLongPathAware Inno Setup directive

### DIFF
--- a/installer/CodexOffline.iss.tpl
+++ b/installer/CodexOffline.iss.tpl
@@ -22,7 +22,6 @@ UninstallDisplayIcon={app}\_internal\app\Codex.exe
 ArchitecturesAllowed=x64compatible
 ArchitecturesInstallIn64BitMode=x64compatible
 PrivilegesRequired=lowest
-UseLongPathAware=yes
 
 [Files]
 Source: "{#MySourceRoot}\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs


### PR DESCRIPTION
## Summary
- Remove invalid `UseLongPathAware=yes` directive from `installer/CodexOffline.iss.tpl`
- This directive is not recognized by Inno Setup (any version), causing the compiler to abort on line 25
- The installer build produces 0 setup exe assets, failing the `verify-offline-package.ps1` verification step
- Windows long path support is already correctly handled via registry (`LongPathsEnabled`) and `git config core.longpaths` in CI

## Test plan
- [ ] CI `build-offline-package` workflow passes on main after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PTg12gmPxFk7FMuwz2gWZF

---
_Generated by [Claude Code](https://claude.ai/code/session_01PTg12gmPxFk7FMuwz2gWZF)_