### PR TITLE
feat: publish a version-matched API model catalog

### DIFF
--- a/.github/workflows/build-offline-package.yml
+++ b/.github/workflows/build-offline-package.yml
@@ -24,6 +24,7 @@ on:
       - 'README.md'
       - 'CHANGELOG.md'
       - 'config/**'
+      - 'docs/models-api.md'
       - 'installer/**'
       - 'package.json'
       - 'package-lock.json'
@@ -38,6 +39,7 @@ on:
       - 'README.md'
       - 'CHANGELOG.md'
       - 'config/**'
+      - 'docs/models-api.md'
       - 'installer/**'
       - 'package.json'
       - 'package-lock.json'
@@ -94,7 +96,9 @@ jobs:
           node --check './scripts/patch-app-asar.mjs'
           node --check './scripts/offline-direct-launch-smoke.mjs'
           node --check './scripts/extract-webview-from-asar.mjs'
+          node --check './scripts/build-api-model-catalog.mjs'
           node --check './web-gateway/start-web.mjs'
+          node --test './scripts/test/api-model-catalog.test.cjs'
           Test-PowerShellSyntax './scripts/build-offline-package.ps1'
           Test-PowerShellSyntax './scripts/verify-offline-package.ps1'
 
@@ -341,6 +345,7 @@ jobs:
           $lines.Add("- portable zip")
           $lines.Add("- setup exe")
           $lines.Add("- bundled skills zip")
+          $lines.Add("- ``models-api.json`` (optional API/custom-provider catalog; see https://github.com/${{ github.repository }}/blob/main/docs/models-api.md)")
           $lines.Add("- SHA256SUMS.txt")
 
           ($lines -join "`n") | Set-Content -Path 'release-notes.md' -Encoding UTF8 -NoNewline

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,18 +4,21 @@
 
 ### 中文
 
+- CI 现在额外发布一个与包内 Codex CLI 精确匹配的 `models-api.json`，合并 DeepSeek 官方条目，并为 GPT-5.6 custom provider 搜索问题提供受校验的临时目录覆盖。
 - 恢复 Activity View 的优先级筛选入口，并让 Fast 模式在离线/API Key 场景保持可见可选。
 - 兼容 Codex `26.803.5235.0` 的 Chrome native pipe、平台分发器和运行时环境变量读取结构，修复最新版无法生成离线包的问题。
 - 增加当前 bundle 结构与离线 UI gate 的回归测试。
 
 ### English
 
+- CI now publishes a `models-api.json` catalog matched to the bundled Codex CLI, combining official DeepSeek entries with a guarded temporary GPT-5.6 custom-provider compatibility override.
 - Restored the Activity View priority filter and kept Fast mode available in offline/API-key sessions.
 - Added compatibility for Codex `26.803.5235.0` Chrome native-pipe, platform-dispatch, and runtime environment-reader shapes, fixing offline package generation for the latest release.
 - Added regression coverage for the current bundle structure and offline UI gates.
 
 ### Verification
 
+- `node --test scripts/test/api-model-catalog.test.cjs`
 - `node --test scripts/test/*.test.cjs`
 - `npm --prefix web-gateway run build:gateway`
 - Full installer and portable package build for Codex `26.803.5235.0`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,14 +4,14 @@
 
 ### 中文
 
-- CI 现在额外发布一个与包内 Codex CLI 精确匹配的 `models-api.json`，合并 DeepSeek 官方条目，并为 GPT-5.6 custom provider 搜索问题提供受校验的临时目录覆盖。
+- 每个 Release 现在额外提供一个与包内 Codex CLI 精确匹配的 `models-api.json`，合并 DeepSeek 官方条目，并为 GPT-5.6 custom provider 搜索问题提供受校验的临时目录覆盖。
 - 恢复 Activity View 的优先级筛选入口，并让 Fast 模式在离线/API Key 场景保持可见可选。
 - 兼容 Codex `26.803.5235.0` 的 Chrome native pipe、平台分发器和运行时环境变量读取结构，修复最新版无法生成离线包的问题。
 - 增加当前 bundle 结构与离线 UI gate 的回归测试。
 
 ### English
 
-- CI now publishes a `models-api.json` catalog matched to the bundled Codex CLI, combining official DeepSeek entries with a guarded temporary GPT-5.6 custom-provider compatibility override.
+- Each Release now includes a `models-api.json` catalog matched to the bundled Codex CLI, combining official DeepSeek entries with a guarded temporary GPT-5.6 custom-provider compatibility override.
 - Restored the Activity View priority filter and kept Fast mode available in offline/API-key sessions.
 - Added compatibility for Codex `26.803.5235.0` Chrome native-pipe, platform-dispatch, and runtime environment-reader shapes, fixing offline package generation for the latest release.
 - Added regression coverage for the current bundle structure and offline UI gates.

--- a/README.md
+++ b/README.md
@@ -136,11 +136,13 @@ pwsh -NoProfile -File ./scripts/build-offline-package.ps1
 3. 给 `app.asar` 打补丁（脱离 MSIX、绕 feature gate、路径修复等）
 4. 拉取官方 skills、下载 primary runtime 插件、Chrome 扩展
 5. 编译 web-gateway TypeScript
-6. 打包：便携 ZIP + 跨平台 Web ZIP + 安装器 EXE
+6. 生成可选 API 模型目录，并打包：便携 ZIP + 跨平台 Web ZIP + 安装器 EXE
 
 ### CI
 
 每天 UTC 3:15 自动检查 Store 版本，有新版则构建发布。`[force-rebuild]` 提交标记可强制重建。
+
+每个 Release 还会提供一个可选的 `models-api.json`，用于 API Key、CRS 和 DeepSeek 等 Responses API 场景。它不会自动启用；下载、配置、原生搜索验证和临时补丁退出条件见 [API/custom provider 模型目录](docs/models-api.md)。
 
 ## 配置
 
@@ -210,7 +212,7 @@ npx playwright install chromium
 pwsh -NoProfile -File ./scripts/build-offline-package.ps1
 ```
 
-Artifacts: `dist/offline/<release>/` — portable zip, web zip, setup exe, SHA256SUMS.
+Artifacts: `dist/offline/<release>/` — portable zip, web zip, setup exe, optional `models-api.json`, and SHA256SUMS.
 
 ### Config
 
@@ -225,6 +227,8 @@ See `config/offline-package.json`. Key fields:
 | `packaging.setupExe` | Generate Inno Setup installer |
 
 CI runs daily at 3:15 UTC. Commits tagged `[force-rebuild]` trigger a rebuild even if the Store version hasn't changed.
+
+Each Release also includes an optional, version-matched `models-api.json` for API-key, CRS, DeepSeek, and other Responses-compatible providers. It is not enabled automatically; see the [API/custom provider model catalog guide](docs/models-api.md).
 
 ### Risks
 

--- a/docs/models-api.md
+++ b/docs/models-api.md
@@ -1,0 +1,104 @@
+# API/custom provider 模型目录
+
+[English](#english)
+
+`models-api.json` 是每个 GitHub Release 附带的可选 Codex 模型目录。它面向 API Key、CRS 和其他 Responses API 兼容 provider；项目不会自动安装或启用它，也不会在文件中写入 API Key。
+
+该文件是完整目录，不是增量补丁：CI 从安装包内 `codex.exe --version` 读取精确的 `codex-cli` 版本，下载对应 `rust-v<version>` 的 OpenAI 官方目录，应用 GPT-5.6 custom-provider 临时修正，再合并 DeepSeek 官方 Codex 目录。
+
+## 安装
+
+1. 从与当前安装包相同版本的 [Releases](https://github.com/lusipad/unofficial-codex-app-offline/releases) 下载 `models-api.json`。
+2. 将文件放到 `CODEX_HOME`；未设置该变量时，默认目录是 `%USERPROFILE%\.codex`。
+3. 在 `CODEX_HOME\config.toml` 中设置文件的绝对路径；未设置 `CODEX_HOME` 时，该配置文件是 `%USERPROFILE%\.codex\config.toml`。Windows TOML 路径使用 `/`：
+
+```toml
+model_catalog_json = "C:/Users/你的用户名/.codex/models-api.json"
+web_search = "live"
+```
+
+`model_catalog_json` 只在 app-server 启动时加载。修改文件或配置后，需要完全退出所有 Codex 进程，再重新启动并新建任务。
+
+## CRS / Responses API 配置示例
+
+以下示例使用环境变量保存密钥。请把 `base_url` 替换为 CRS 实际提供的 Responses API 根地址：
+
+```toml
+model = "gpt-5.6-sol"
+model_provider = "crs"
+model_catalog_json = "C:/Users/你的用户名/.codex/models-api.json"
+web_search = "live"
+
+[model_providers.crs]
+name = "CRS"
+base_url = "https://你的-CRS-地址/v1"
+env_key = "CRS_API_KEY"
+wire_api = "responses"
+```
+
+GPT-5.6 官方条目原本已经声明 `supports_search_tool = true`。目录只对以下字段应用临时兼容覆盖，避免 custom provider 请求使用 Codex 后端专用的 Responses Lite / collaboration 形状：
+
+```json
+{
+  "tool_mode": null,
+  "multi_agent_version": null,
+  "use_responses_lite": false
+}
+```
+
+这只能保证 Codex 构造原生 `web_search` 工具请求。CRS 仍必须支持并透传 Responses API 的托管 `web_search`；目录文件无法为不支持搜索的中转增加该能力。
+
+## DeepSeek 配置示例
+
+截至本文更新时，DeepSeek 官方 Codex 指南只确认 `deepseek-v4-flash` 可用。目录也保留官方提供的 `deepseek-v4-pro` 条目，但在官方确认支持前请使用 Flash。
+
+```toml
+model = "deepseek-v4-flash"
+model_provider = "deepseek"
+preferred_auth_method = "apikey"
+forced_login_method = "api"
+model_reasoning_effort = "high"
+model_catalog_json = "C:/Users/你的用户名/.codex/models-api.json"
+web_search = "live"
+
+[model_providers.deepseek]
+name = "DeepSeek"
+base_url = "https://api.deepseek.com/"
+env_key = "DEEPSEEK_API_KEY"
+wire_api = "responses"
+```
+
+## 模型与 provider 必须手动匹配
+
+一个目录会同时显示 GPT 和 DeepSeek 模型，但 Codex 的模型条目不绑定 provider。模型选择器只切换模型名，不会同步修改 `model_provider`：
+
+- `gpt-*` 应配合 OpenAI、CRS 或相应 OpenAI Responses 兼容 provider。
+- `deepseek-*` 应配合 `deepseek` provider。
+
+如果二者不匹配，请求会发送到错误的 API 地址并失败。切换 provider 时请编辑用户级 `config.toml` 并完全重启 Codex。
+
+## 验证原生搜索
+
+为了排除 Browser、Chrome 或 Computer Use 回退，可以暂时禁用这些工具，然后要求模型只使用原生 `web_search`。成功时，请求或事件日志应包含 `web_search` / `response.web_search_call.*`，而不是浏览器工具调用。
+
+## 数据来源和维护
+
+- OpenAI 基础目录：[`openai/codex`](https://github.com/openai/codex) 中与包内 CLI 精确匹配的 `rust-v<codex-cli-version>/codex-rs/models-manager/models.json`，不使用会持续变化的 `main`。
+- DeepSeek 条目：[DeepSeek Codex 集成指南](https://api-docs.deepseek.com/quick_start/agent_integrations/codex/)提供的官方安装脚本。CI 校验提取后目录的内容指纹；上游内容变化时会停止发布，要求人工复核。
+- GPT-5.6 临时修正对应上游问题 [openai/codex#31882](https://github.com/openai/codex/issues/31882) 和 [openai/codex#33250](https://github.com/openai/codex/issues/33250)。
+
+退出条件：安装包内 Codex 已验证修复 custom-provider 工具注入后，删除 GPT-5.6 覆盖；Codex 原生支持 DeepSeek/provider 专属目录后，删除 DeepSeek 合并。如果两项都完成，就停止发布该文件。
+
+---
+
+<a id="english"></a>
+
+## English
+
+`models-api.json` is an optional, version-matched Codex catalog for API-key and Responses-compatible custom providers. It is a full replacement catalog, not a partial overlay.
+
+Download it from the same GitHub Release as the app, copy it into `CODEX_HOME`, set an absolute `model_catalog_json` path in `CODEX_HOME/config.toml` (by default `%USERPROFILE%/.codex/config.toml`), and fully restart Codex. The catalog lists both GPT and DeepSeek models, but it does not bind models to providers; keep `gpt-*` on the matching OpenAI/CRS provider and `deepseek-*` on the DeepSeek provider.
+
+The GPT-5.6 entries retain their official search metadata while temporarily disabling `tool_mode`, `multi_agent_version`, and Responses Lite for custom-provider compatibility. The provider must still implement or forward hosted Responses API `web_search`.
+
+CI builds the file from the exact OpenAI catalog tag matching the bundled CLI and from DeepSeek's official Codex setup catalog. Upstream metadata changes fail the build for review instead of silently changing the Release asset. See the Chinese sections above for complete CRS and DeepSeek configuration examples and removal criteria.

--- a/scripts/build-api-model-catalog.mjs
+++ b/scripts/build-api-model-catalog.mjs
@@ -1,0 +1,269 @@
+#!/usr/bin/env node
+
+import { execFile } from "node:child_process";
+import { createHash } from "node:crypto";
+import { mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { promisify } from "node:util";
+import { fileURLToPath } from "node:url";
+
+const execFileAsync = promisify(execFile);
+
+const OPENAI_CATALOG_URL =
+  "https://raw.githubusercontent.com/openai/codex/rust-v{version}/codex-rs/models-manager/models.json";
+const DEEPSEEK_SETUP_URL =
+  "https://cdn.deepseek.com/api-docs/codex-deepseek-setup-en.ps1";
+const DEEPSEEK_CATALOG_SHA256 =
+  "2f4295501fc41902cb78cfc4b9101ca09c6d89644c83adaadf7a23590b6735c5";
+
+const GPT_56_SLUGS = ["gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"];
+const GPT_56_UPSTREAM_MULTI_AGENT_VERSIONS = Object.freeze({
+  "gpt-5.6-sol": "v2",
+  "gpt-5.6-terra": "v2",
+  "gpt-5.6-luna": "v1",
+});
+const DEEPSEEK_SLUGS = ["deepseek-v4-flash", "deepseek-v4-pro"];
+const GPT_56_CUSTOM_PROVIDER_PATCH = Object.freeze({
+  tool_mode: null,
+  multi_agent_version: null,
+  use_responses_lite: false,
+});
+
+function usage() {
+  return [
+    "Usage:",
+    "  node scripts/build-api-model-catalog.mjs --codex-binary <path> --output <path>",
+    "  node scripts/build-api-model-catalog.mjs --codex-version <version> --output <path>",
+  ].join("\n");
+}
+
+function parseArgs(argv) {
+  const values = {};
+  for (let index = 0; index < argv.length; index += 1) {
+    const key = argv[index];
+    if (!["--codex-binary", "--codex-version", "--output"].includes(key)) {
+      throw new Error(`Unknown argument: ${key}\n${usage()}`);
+    }
+    const value = argv[index + 1];
+    if (!value || value.startsWith("--")) {
+      throw new Error(`Missing value for ${key}\n${usage()}`);
+    }
+    values[key.slice(2)] = value;
+    index += 1;
+  }
+
+  if (!values.output) {
+    throw new Error(`--output is required\n${usage()}`);
+  }
+  if (Boolean(values["codex-binary"]) === Boolean(values["codex-version"])) {
+    throw new Error(
+      `Specify exactly one of --codex-binary or --codex-version\n${usage()}`,
+    );
+  }
+  return values;
+}
+
+function normalizeVersion(version) {
+  const normalized = String(version).trim().replace(/^v/, "");
+  if (!/^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/.test(normalized)) {
+    throw new Error(`Unsupported Codex version: ${version}`);
+  }
+  return normalized;
+}
+
+export function parseCodexVersion(output) {
+  const match = String(output).match(/\bcodex-cli\s+([^\s]+)/);
+  if (!match) {
+    throw new Error(`Could not parse Codex version from: ${String(output).trim()}`);
+  }
+  return normalizeVersion(match[1]);
+}
+
+async function readCodexVersion(binaryPath) {
+  const { stdout, stderr } = await execFileAsync(binaryPath, ["--version"], {
+    encoding: "utf8",
+    timeout: 30_000,
+    windowsHide: true,
+  });
+  return parseCodexVersion(`${stdout}\n${stderr}`);
+}
+
+async function fetchText(url, label) {
+  const response = await fetch(url, {
+    headers: { "user-agent": "codex-app-offline-model-catalog-builder" },
+    signal: AbortSignal.timeout(60_000),
+  });
+  if (!response.ok) {
+    throw new Error(`${label} download failed: HTTP ${response.status} ${url}`);
+  }
+  return response.text();
+}
+
+function parseCatalog(text, label) {
+  let catalog;
+  try {
+    catalog = JSON.parse(text);
+  } catch (error) {
+    throw new Error(`${label} is not valid JSON: ${error.message}`);
+  }
+  validateCatalog(catalog, label);
+  return catalog;
+}
+
+function validateCatalog(catalog, label) {
+  if (!catalog || typeof catalog !== "object" || !Array.isArray(catalog.models)) {
+    throw new Error(`${label} must contain a models array`);
+  }
+
+  const slugs = new Set();
+  for (const model of catalog.models) {
+    if (!model || typeof model !== "object" || typeof model.slug !== "string") {
+      throw new Error(`${label} contains a model without a string slug`);
+    }
+    if (slugs.has(model.slug)) {
+      throw new Error(`${label} contains duplicate model slug: ${model.slug}`);
+    }
+    slugs.add(model.slug);
+  }
+}
+
+function sortForHash(value) {
+  if (Array.isArray(value)) return value.map(sortForHash);
+  if (!value || typeof value !== "object") return value;
+  return Object.fromEntries(
+    Object.keys(value)
+      .sort()
+      .map((key) => [key, sortForHash(value[key])]),
+  );
+}
+
+export function catalogSha256(catalog) {
+  return createHash("sha256")
+    .update(JSON.stringify(sortForHash(catalog)))
+    .digest("hex");
+}
+
+export function extractDeepSeekCatalog(setupScript) {
+  const match = String(setupScript).match(
+    /^\s*\$ModelsJson\s*=\s*@'\r?\n(?<json>\{[\s\S]*?\})\r?\n'@\s*$/m,
+  );
+  if (!match?.groups?.json) {
+    throw new Error("DeepSeek setup script does not contain the expected ModelsJson block");
+  }
+  return parseCatalog(match.groups.json, "DeepSeek model catalog");
+}
+
+function clone(value) {
+  return JSON.parse(JSON.stringify(value));
+}
+
+export function mergeModelCatalogs(openAiCatalog, deepSeekCatalog) {
+  validateCatalog(openAiCatalog, "OpenAI model catalog");
+  validateCatalog(deepSeekCatalog, "DeepSeek model catalog");
+
+  const merged = clone(openAiCatalog);
+  const modelsBySlug = new Map(merged.models.map((model) => [model.slug, model]));
+
+  for (const slug of GPT_56_SLUGS) {
+    const model = modelsBySlug.get(slug);
+    if (!model) {
+      throw new Error(`OpenAI model catalog is missing required model: ${slug}`);
+    }
+    if (model.supports_search_tool !== true || !model.web_search_tool_type) {
+      throw new Error(`${slug} no longer advertises native web search; review the patch`);
+    }
+    if (
+      model.tool_mode !== "code_mode_only" ||
+      model.multi_agent_version !== GPT_56_UPSTREAM_MULTI_AGENT_VERSIONS[slug] ||
+      model.use_responses_lite !== true
+    ) {
+      throw new Error(`${slug} compatibility fields changed upstream; review the temporary patch`);
+    }
+    Object.assign(model, GPT_56_CUSTOM_PROVIDER_PATCH);
+  }
+
+  const deepSeekModels = new Map(
+    deepSeekCatalog.models.map((model) => [model.slug, clone(model)]),
+  );
+  for (const slug of DEEPSEEK_SLUGS) {
+    const model = deepSeekModels.get(slug);
+    if (!model) {
+      throw new Error(`DeepSeek model catalog is missing required model: ${slug}`);
+    }
+    if (
+      model.supports_search_tool !== true ||
+      model.web_search_tool_type !== "text" ||
+      model.use_responses_lite !== false
+    ) {
+      throw new Error(`${slug} capability fields changed upstream; review before publishing`);
+    }
+  }
+
+  for (const model of deepSeekCatalog.models) {
+    if (modelsBySlug.has(model.slug)) {
+      throw new Error(
+        `OpenAI catalog now contains ${model.slug}; remove the manual DeepSeek merge`,
+      );
+    }
+    merged.models.push(clone(model));
+    modelsBySlug.set(model.slug, model);
+  }
+
+  validateCatalog(merged, "Merged API model catalog");
+  return merged;
+}
+
+export async function buildApiModelCatalog({ codexVersion, outputPath }) {
+  const version = normalizeVersion(codexVersion);
+  const openAiUrl = OPENAI_CATALOG_URL.replace("{version}", version);
+  const [openAiText, deepSeekSetupScript] = await Promise.all([
+    fetchText(openAiUrl, "OpenAI model catalog"),
+    fetchText(DEEPSEEK_SETUP_URL, "DeepSeek setup script"),
+  ]);
+
+  const openAiCatalog = parseCatalog(openAiText, "OpenAI model catalog");
+  const deepSeekCatalog = extractDeepSeekCatalog(deepSeekSetupScript);
+  const deepSeekHash = catalogSha256(deepSeekCatalog);
+  if (deepSeekHash !== DEEPSEEK_CATALOG_SHA256) {
+    throw new Error(
+      `DeepSeek model catalog changed (${deepSeekHash}); review it and update the pinned hash`,
+    );
+  }
+
+  const merged = mergeModelCatalogs(openAiCatalog, deepSeekCatalog);
+  const resolvedOutput = path.resolve(outputPath);
+  await mkdir(path.dirname(resolvedOutput), { recursive: true });
+  await writeFile(resolvedOutput, `${JSON.stringify(merged, null, 2)}\n`, "utf8");
+
+  return {
+    codexVersion: version,
+    deepSeekCatalogSha256: deepSeekHash,
+    modelCount: merged.models.length,
+    openAiCatalogUrl: openAiUrl,
+    deepSeekSetupUrl: DEEPSEEK_SETUP_URL,
+    outputPath: resolvedOutput,
+  };
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const codexVersion = args["codex-version"]
+    ? normalizeVersion(args["codex-version"])
+    : await readCodexVersion(path.resolve(args["codex-binary"]));
+  const result = await buildApiModelCatalog({
+    codexVersion,
+    outputPath: args.output,
+  });
+  process.stdout.write(`${JSON.stringify(result)}\n`);
+}
+
+const isMain = process.argv[1]
+  ? path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)
+  : false;
+
+if (isMain) {
+  main().catch((error) => {
+    process.stderr.write(`${error.stack || error.message}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/build-offline-package.ps1
+++ b/scripts/build-offline-package.ps1
@@ -878,6 +878,18 @@ $buildInfo | ConvertTo-Json -Depth 8 | Set-Content -Path (Join-Path $internalRoo
 
 $assets = [System.Collections.Generic.List[string]]::new()
 
+Write-BuildTrace 'Building optional API model catalog release asset.'
+$modelCatalogBuilder = Join-Path $scriptRoot 'build-api-model-catalog.mjs'
+$modelCatalogAsset = Join-Path $artifactRoot 'models-api.json'
+$bundledCodexBinary = Join-Path $internalRoot 'app\resources\codex.exe'
+& node $modelCatalogBuilder `
+    --codex-binary $bundledCodexBinary `
+    --output $modelCatalogAsset
+if ($LASTEXITCODE -ne 0) {
+    throw "API model catalog generation failed with exit code $LASTEXITCODE."
+}
+$assets.Add($modelCatalogAsset) | Out-Null
+
 Write-BuildTrace 'Creating archives.'
 # Hide implementation details AFTER creating portable zip so Compress-Archive includes hidden items.
 if ($config.packaging.portableZip) {

--- a/scripts/test/api-model-catalog.test.cjs
+++ b/scripts/test/api-model-catalog.test.cjs
@@ -1,0 +1,141 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const path = require("node:path");
+const test = require("node:test");
+const { pathToFileURL } = require("node:url");
+
+const modulePromise = import(
+  pathToFileURL(path.resolve(__dirname, "../build-api-model-catalog.mjs"))
+);
+
+function openAiModel(slug, multiAgentVersion = "v2") {
+  return {
+    slug,
+    display_name: slug,
+    supports_search_tool: true,
+    web_search_tool_type: "text_and_image",
+    tool_mode: "code_mode_only",
+    multi_agent_version: multiAgentVersion,
+    use_responses_lite: true,
+  };
+}
+
+function deepSeekModel(slug) {
+  return {
+    slug,
+    display_name: slug,
+    supports_search_tool: true,
+    web_search_tool_type: "text",
+    tool_mode: null,
+    multi_agent_version: "v2",
+    use_responses_lite: false,
+  };
+}
+
+function fixtures() {
+  return {
+    openAi: {
+      models: [
+        { slug: "gpt-5.5", display_name: "GPT-5.5" },
+        openAiModel("gpt-5.6-sol"),
+        openAiModel("gpt-5.6-terra"),
+        openAiModel("gpt-5.6-luna", "v1"),
+      ],
+    },
+    deepSeek: {
+      models: [
+        deepSeekModel("deepseek-v4-flash"),
+        deepSeekModel("deepseek-v4-pro"),
+      ],
+    },
+  };
+}
+
+test("merges DeepSeek entries and applies only the GPT-5.6 provider workaround", async () => {
+  const { mergeModelCatalogs } = await modulePromise;
+  const { openAi, deepSeek } = fixtures();
+  const merged = mergeModelCatalogs(openAi, deepSeek);
+  const expected = structuredClone(openAi);
+  for (const slug of ["gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"]) {
+    Object.assign(
+      expected.models.find((model) => model.slug === slug),
+      {
+        tool_mode: null,
+        multi_agent_version: null,
+        use_responses_lite: false,
+      },
+    );
+  }
+  expected.models.push(...structuredClone(deepSeek.models));
+
+  assert.deepEqual(merged, expected);
+
+  assert.deepEqual(
+    merged.models.map((model) => model.slug),
+    [
+      "gpt-5.5",
+      "gpt-5.6-sol",
+      "gpt-5.6-terra",
+      "gpt-5.6-luna",
+      "deepseek-v4-flash",
+      "deepseek-v4-pro",
+    ],
+  );
+  assert.deepEqual(merged.models[0], openAi.models[0]);
+
+  for (const slug of ["gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"]) {
+    const model = merged.models.find((entry) => entry.slug === slug);
+    assert.equal(model.tool_mode, null);
+    assert.equal(model.multi_agent_version, null);
+    assert.equal(model.use_responses_lite, false);
+    assert.equal(model.supports_search_tool, true);
+    assert.equal(model.web_search_tool_type, "text_and_image");
+  }
+
+  assert.equal(openAi.models[1].tool_mode, "code_mode_only");
+  assert.equal(openAi.models[1].use_responses_lite, true);
+});
+
+test("extracts the official DeepSeek ModelsJson PowerShell block", async () => {
+  const { extractDeepSeekCatalog } = await modulePromise;
+  const script = [
+    "$ModelsJson = @'",
+    JSON.stringify(fixtures().deepSeek, null, 2),
+    "'@",
+  ].join("\n");
+
+  assert.deepEqual(extractDeepSeekCatalog(script), fixtures().deepSeek);
+});
+
+test("rejects an upstream GPT-5.6 metadata change instead of silently overwriting it", async () => {
+  const { mergeModelCatalogs } = await modulePromise;
+  for (const [field, value] of [
+    ["tool_mode", null],
+    ["multi_agent_version", null],
+    ["use_responses_lite", false],
+  ]) {
+    const { openAi, deepSeek } = fixtures();
+    openAi.models.find((model) => model.slug === "gpt-5.6-sol")[field] = value;
+    assert.throws(
+      () => mergeModelCatalogs(openAi, deepSeek),
+      /compatibility fields changed upstream/,
+    );
+  }
+});
+
+test("rejects duplicate DeepSeek slugs already supplied by OpenAI", async () => {
+  const { mergeModelCatalogs } = await modulePromise;
+  const { openAi, deepSeek } = fixtures();
+  openAi.models.push(deepSeekModel("deepseek-v4-flash"));
+
+  assert.throws(
+    () => mergeModelCatalogs(openAi, deepSeek),
+    /remove the manual DeepSeek merge/,
+  );
+});
+
+test("parses the exact Codex CLI prerelease version", async () => {
+  const { parseCodexVersion } = await modulePromise;
+  assert.equal(parseCodexVersion("codex-cli 0.147.0-alpha.6.5\n"), "0.147.0-alpha.6.5");
+});

--- a/scripts/verify-offline-package.ps1
+++ b/scripts/verify-offline-package.ps1
@@ -208,6 +208,7 @@ $webAssets = @($metadataAssets | Where-Object { $_.fileName -like '*-web.zip' })
 $skillsAssets = @($metadataAssets | Where-Object { $_.fileName -like '*-skills.zip' })
 $installerAssets = @($metadataAssets | Where-Object { $_.fileName -like '*-setup.exe' })
 $storeExportAssets = @($metadataAssets | Where-Object { $_.fileName -like '*-store-export.zip' })
+$modelCatalogAssets = @($metadataAssets | Where-Object { $_.fileName -eq 'models-api.json' })
 $checksumAssets = @($metadataAssets | Where-Object { $_.fileName -eq 'SHA256SUMS.txt' })
 $crossPlatformWebEnabled = $null -ne $config.packaging.PSObject.Properties['crossPlatformWeb'] -and [bool]$config.packaging.crossPlatformWeb
 
@@ -249,6 +250,10 @@ if ($checksumAssets.Count -ne 1) {
     throw "Expected exactly one SHA256SUMS.txt asset, found $($checksumAssets.Count)."
 }
 
+if ($modelCatalogAssets.Count -ne 1) {
+    throw "Expected exactly one models-api.json asset, found $($modelCatalogAssets.Count)."
+}
+
 if (-not $config.packaging.sourceExportArchive -and $storeExportAssets.Count -gt 0) {
     throw 'Store export zip is disabled, but a *-store-export.zip asset was still produced.'
 }
@@ -266,6 +271,49 @@ foreach ($asset in $metadataAssets) {
     $assetPath = Join-Path $artifactRoot $asset.fileName
     if (-not (Test-Path $assetPath)) {
         throw "Metadata listed an asset that does not exist on disk: $assetPath"
+    }
+}
+
+$modelCatalogPath = Join-Path $artifactRoot $modelCatalogAssets[0].fileName
+Assert-FileHasNoUtf8Bom -Path $modelCatalogPath -Context 'API model catalog'
+try {
+    $modelCatalog = Get-Content -Path $modelCatalogPath -Raw -Encoding UTF8 | ConvertFrom-Json
+} catch {
+    throw "API model catalog is not valid JSON: $($_.Exception.Message)"
+}
+
+$modelCatalogModels = @($modelCatalog.models)
+if ($modelCatalogModels.Count -eq 0) {
+    throw 'API model catalog does not contain any models.'
+}
+$modelCatalogSlugs = @($modelCatalogModels | ForEach-Object { [string]$_.slug })
+if (@($modelCatalogSlugs | Sort-Object -Unique).Count -ne $modelCatalogSlugs.Count) {
+    throw 'API model catalog contains duplicate model slugs.'
+}
+
+foreach ($slug in @('gpt-5.6-sol', 'gpt-5.6-terra', 'gpt-5.6-luna')) {
+    $model = @($modelCatalogModels | Where-Object { $_.slug -eq $slug })
+    if ($model.Count -ne 1) {
+        throw "API model catalog must contain exactly one $slug entry."
+    }
+    if ($null -ne $model[0].tool_mode -or
+        $null -ne $model[0].multi_agent_version -or
+        $model[0].use_responses_lite -ne $false -or
+        $model[0].supports_search_tool -ne $true -or
+        [string]::IsNullOrWhiteSpace([string]$model[0].web_search_tool_type)) {
+        throw "API model catalog has unexpected custom-provider fields for $slug."
+    }
+}
+
+foreach ($slug in @('deepseek-v4-flash', 'deepseek-v4-pro')) {
+    $model = @($modelCatalogModels | Where-Object { $_.slug -eq $slug })
+    if ($model.Count -ne 1) {
+        throw "API model catalog must contain exactly one $slug entry."
+    }
+    if ($model[0].supports_search_tool -ne $true -or
+        $model[0].web_search_tool_type -ne 'text' -or
+        $model[0].use_responses_lite -ne $false) {
+        throw "API model catalog has unexpected DeepSeek fields for $slug."
     }
 }
 
@@ -314,6 +362,7 @@ try {
         '_internal\tools\Repair Chrome Host.cmd',
         '_internal\app\ChatGPT.exe',
         '_internal\app\resources\app.asar',
+        '_internal\app\resources\codex.exe',
         '_internal\patches\init.cjs',
         '_internal\app\patches\init.cjs',
         '_internal\powershell-shim\CodexOfflineShim\CodexOfflineShim.psd1',
@@ -326,6 +375,32 @@ try {
         $fullPath = Join-Path $portableRoot $relativePath
         if (-not (Test-Path $fullPath)) {
             throw "Portable zip is missing required file: $relativePath"
+        }
+    }
+
+    $portableCodexBinary = Join-Path $portableRoot '_internal\app\resources\codex.exe'
+    $catalogTomlPath = $modelCatalogPath.Replace('\', '/')
+    $catalogOverride = 'model_catalog_json="' + $catalogTomlPath + '"'
+    $previousCodexHome = $env:CODEX_HOME
+    try {
+        $env:CODEX_HOME = Join-Path $tempRoot 'model-catalog-codex-home'
+        New-Item -ItemType Directory -Force -Path $env:CODEX_HOME | Out-Null
+        $catalogDebugOutput = & $portableCodexBinary -c $catalogOverride debug models
+        if ($LASTEXITCODE -ne 0) {
+            throw "Bundled Codex rejected models-api.json with exit code $LASTEXITCODE."
+        }
+        $loadedCatalog = $catalogDebugOutput -join [Environment]::NewLine | ConvertFrom-Json
+        $loadedSlugs = @($loadedCatalog.models | ForEach-Object { [string]$_.slug })
+        foreach ($slug in @('gpt-5.6-sol', 'deepseek-v4-flash', 'deepseek-v4-pro')) {
+            if ($loadedSlugs -notcontains $slug) {
+                throw "Bundled Codex did not load expected model from models-api.json: $slug"
+            }
+        }
+    } finally {
+        if ($null -eq $previousCodexHome) {
+            Remove-Item Env:CODEX_HOME -ErrorAction SilentlyContinue
+        } else {
+            $env:CODEX_HOME = $previousCodexHome
         }
     }
 


### PR DESCRIPTION
## Summary

- publish a version-matched `models-api.json` with every offline release
- preserve the full official OpenAI catalog, apply the guarded GPT-5.6 custom-provider search workaround, and append pinned official DeepSeek entries
- verify the asset with the bundled Codex CLI and document setup, provider matching, sources, and removal criteria

## Verification

- `node --test` across all 7 script test files: 68/68 passed
- `npm --prefix web-gateway run build:gateway`
- PowerShell syntax parsing for build and verifier scripts
- full offline package build and package verifier
- native Responses API `web_search` smoke with GPT-5.6 Sol and Terra

## Scope

Only the 8 product, CI, test, and user-documentation files are included. Internal implementation notes are intentionally excluded.

## Documentation

- `README.md`: advertises the optional Release asset in Chinese and English and links the setup guide.
- `CHANGELOG.md`: records the new downloadable catalog and its verification commands in user-facing language.
- `docs/models-api.md`: documents installation, CRS and DeepSeek configuration, manual provider matching, native search verification, official data sources, and patch removal criteria.
- Internal implementation notes are intentionally excluded from this PR.
