### PR TITLE
Keep offline plugin markets usable behind blocked Internet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,14 +4,14 @@
 
 ### 中文
 
-- 修复系统处于离线状态时，本地和内网插件市场查询被暂停的问题；本地插件查询与安装保持可用，云端目录失败时降级为空结果，不再遮蔽可用的内网市场。
+- 修复系统离线或 Windows 仍报告在线但外网被策略拒绝（如 `net::ERR_NETWORK_ACCESS_DENIED`）时，插件页遮蔽本地和内网市场的问题；明确的 Chromium 网络不可达错误会让云端目录降级为空结果，本地插件查询与安装保持可用。
 - 恢复离线状态下 Activity 视图的优先级筛选入口，并让 Skills 页面继续加载本地插件管理数据。
 - 不再强制开启依赖云服务的远程连接功能开关，避免离线界面暴露不可用入口。
 - 将完整脚本回归测试纳入发布工作流，覆盖离线 UI、插件市场和模型目录补丁。
 
 ### English
 
-- Fixed local and intranet plugin marketplace queries being paused when Windows reports an offline network state. Local plugin queries and installs remain runnable, while unavailable cloud catalogs degrade to empty results without hiding reachable intranet marketplaces.
+- Fixed local and intranet marketplaces being hidden when Windows reports online while external access is policy-blocked (for example, `net::ERR_NETWORK_ACCESS_DENIED`), as well as when Windows reports offline. Known Chromium network-unavailable errors now degrade cloud catalogs to empty results while local plugin queries and installs remain runnable.
 - Restored the Activity priority filter while offline and kept local plugin-management data loading on the Skills page.
 - Stopped forcing cloud-only remote connection gates in offline builds, avoiding unusable UI entries.
 - Added the complete script regression suite to the release workflow, covering offline UI, plugin marketplace, and model-catalog patches.

--- a/scripts/patch-app-asar.mjs
+++ b/scripts/patch-app-asar.mjs
@@ -778,10 +778,39 @@ function patchOfflinePluginQueries(content) {
   const pluginQueryNetworkMode = key =>
     `networkMode:\`always\`${PLUGIN_QUERY_NETWORK_MODE_PATCH_MARKER}` +
     `/*codex-offline:plugin-query-surface:${key}*/`;
+  const cloudUnavailableErrorNames = [
+    'ERR_NETWORK_ACCESS_DENIED',
+    'ERR_PROXY_CONNECTION_FAILED',
+    'ERR_INTERNET_DISCONNECTED',
+    'ERR_NAME_NOT_RESOLVED',
+    'ERR_NAME_RESOLUTION_FAILED',
+    'ERR_ADDRESS_UNREACHABLE',
+    'ERR_CONNECTION_REFUSED',
+    'ERR_CONNECTION_TIMED_OUT',
+  ];
+  const cloudUnavailable =
+    `globalThis.navigator?.onLine===!1||/(?:${cloudUnavailableErrorNames.join('|')})/` +
+    '.test(String(e?.message??e))';
   const offlineCloudFallback = (key, emptyValue) =>
+    `.catch(e=>${cloudUnavailable}?(${emptyValue}):Promise.reject(e))` +
+    `${PLUGIN_CLOUD_FALLBACK_PATCH_MARKER}` +
+    `/*codex-offline:plugin-fallback-surface:${key}*/`;
+  const legacyOfflineCloudFallback = (key, emptyValue) =>
     `.catch(e=>globalThis.navigator?.onLine===!1?(${emptyValue}):Promise.reject(e))` +
     `${PLUGIN_CLOUD_FALLBACK_PATCH_MARKER}` +
     `/*codex-offline:plugin-fallback-surface:${key}*/`;
+  for (const [key, emptyValue] of [
+    ['cloud-home', '{sections:[]}'],
+    ['cloud-user-list', '{plugins:[]}'],
+    ['cloud-workspace-created', '{plugins:[]}'],
+    ['cloud-workspace-shared', '{plugins:[]}'],
+    ['cloud-workspace-list', '{plugins:[],pagination:{next_page_token:null}}'],
+  ]) {
+    const legacy = legacyOfflineCloudFallback(key, emptyValue);
+    if (!next.includes(legacy)) continue;
+    next = next.replace(legacy, offlineCloudFallback(key, emptyValue));
+    patched = true;
+  }
   const replacements = [
     [
       'local-directory',

--- a/scripts/test/offline-ui-gates.test.cjs
+++ b/scripts/test/offline-ui-gates.test.cjs
@@ -277,7 +277,7 @@ test("renderer defaults run local queries and mutations while the OS is offline"
   }
 });
 
-test("offline plugin queries force local IPC online and cloud plugin views degrade gracefully", () => {
+test("offline plugin queries force local IPC online and cloud plugin views degrade gracefully", async () => {
   const functionStart = patchScriptSource.indexOf("function patchOfflinePluginQueries");
   const functionEnd = patchScriptSource.indexOf(
     "\nfunction patchWorkspaceDependenciesSettingsGate",
@@ -336,6 +336,16 @@ test("offline plugin queries force local IPC online and cloud plugin views degra
     );
   }
   assert.match(result.content, /globalThis\.navigator\?\.onLine===!1/);
+  assert.match(result.content, /ERR_NETWORK_ACCESS_DENIED/);
+  assert.match(result.content, /ERR_PROXY_CONNECTION_FAILED/);
+  assert.ok(
+    verifyScriptSource.includes(
+      "ERR_NETWORK_ACCESS_DENIED",
+    ) && verifyScriptSource.includes(
+      "ERR_PROXY_CONNECTION_FAILED",
+    ),
+    "package verifier must reject the navigator-only fallback",
+  );
   assert.match(result.content, /Promise\.reject\(e\)/);
   assert.equal(result.content.includes(".catch(()=>"), false);
   assert.equal(
@@ -346,6 +356,65 @@ test("offline plugin queries force local IPC online and cloud plugin views degra
     "patched workspace/shared query must not match the verifier's unpatched boundary",
   );
   assert.deepEqual(result.correctKeys.sort(), result.expectedKeys.sort());
+
+  for (const [key, emptyValue] of [
+    ["cloud-home", { sections: [] }],
+    ["cloud-user-list", { plugins: [] }],
+    ["cloud-workspace-created", { plugins: [] }],
+    ["cloud-workspace-shared", { plugins: [] }],
+    ["cloud-workspace-list", { plugins: [], pagination: { next_page_token: null } }],
+  ]) {
+    const marker =
+      `/*codex-offline:plugin-cloud-fallback*/` +
+      `/*codex-offline:plugin-fallback-surface:${key}*/`;
+    const markerIndex = result.content.indexOf(marker);
+    const catchIndex = result.content.lastIndexOf(".catch(", markerIndex);
+    assert.notEqual(markerIndex, -1, key);
+    assert.notEqual(catchIndex, -1, key);
+    const callbackSource = result.content.slice(
+      catchIndex + ".catch(".length,
+      markerIndex - 1,
+    );
+    const callback = Function(
+      "globalThis",
+      `"use strict"; return (${callbackSource});`,
+    )({ navigator: { onLine: true } });
+
+    for (const errorName of [
+      "ERR_NETWORK_ACCESS_DENIED",
+      "ERR_PROXY_CONNECTION_FAILED",
+      "ERR_INTERNET_DISCONNECTED",
+      "ERR_NAME_NOT_RESOLVED",
+      "ERR_NAME_RESOLUTION_FAILED",
+      "ERR_ADDRESS_UNREACHABLE",
+      "ERR_CONNECTION_REFUSED",
+      "ERR_CONNECTION_TIMED_OUT",
+    ]) {
+      assert.deepEqual(
+        await callback(new Error(`net::${errorName}`)),
+        emptyValue,
+        `${key} must degrade ${errorName} to its empty cloud result`,
+      );
+    }
+
+    const serviceError = new Error("HTTP 503 Service Unavailable");
+    await assert.rejects(callback(serviceError), error => error === serviceError);
+  }
+
+  const legacyCloudHomeFixture =
+    "queryKey:[...mL,`home`,e],queryFn:()=>K_.safeGet(`/ps/plugins/home`).catch(e=>globalThis.navigator?.onLine===!1?({sections:[]}):Promise.reject(e))" +
+    "/*codex-offline:plugin-cloud-fallback*//*codex-offline:plugin-fallback-surface:cloud-home*/,retry:!1," +
+    "networkMode:`always`/*codex-offline:plugin-query-network-mode*//*codex-offline:plugin-query-surface:cloud-home*/,staleTime:ym.ONE_MINUTE";
+  const legacyUpgrade = patchOfflinePluginQueries(legacyCloudHomeFixture);
+  assert.equal(legacyUpgrade.patched, true);
+  assert.match(legacyUpgrade.content, /ERR_NETWORK_ACCESS_DENIED/);
+  assert.equal(
+    legacyUpgrade.content.includes(
+      ".catch(e=>globalThis.navigator?.onLine===!1?",
+    ),
+    false,
+    "packages built with the navigator-only fallback must be upgraded",
+  );
 
   const secondPass = patchOfflinePluginQueries(result.content);
   assert.equal(secondPass.patched, false);

--- a/scripts/verify-offline-package.ps1
+++ b/scripts/verify-offline-package.ps1
@@ -1330,6 +1330,16 @@ const REQUIRED_PLUGIN_FALLBACK_SURFACES = [
   'cloud-workspace-shared',
   'cloud-workspace-list',
 ];
+const REQUIRED_PLUGIN_CLOUD_UNAVAILABLE_ERRORS = [
+  'ERR_NETWORK_ACCESS_DENIED',
+  'ERR_PROXY_CONNECTION_FAILED',
+  'ERR_INTERNET_DISCONNECTED',
+  'ERR_NAME_NOT_RESOLVED',
+  'ERR_NAME_RESOLUTION_FAILED',
+  'ERR_ADDRESS_UNREACHABLE',
+  'ERR_CONNECTION_REFUSED',
+  'ERR_CONNECTION_TIMED_OUT',
+];
 function pluginQuerySurfaceMarker(key) {
   return PLUGIN_QUERY_NETWORK_MODE_PATCH_MARKER +
     `/*codex-offline:plugin-query-surface:${key}*/`;
@@ -1569,7 +1579,16 @@ for (const entry of javaScriptEntries) {
       }
     }
     for (const key of REQUIRED_PLUGIN_FALLBACK_SURFACES) {
-      if (content.includes(pluginFallbackSurfaceMarker(key))) {
+      const markerIndex = content.indexOf(pluginFallbackSurfaceMarker(key));
+      const catchIndex = content.lastIndexOf('.catch(e=>', markerIndex);
+      const fallbackSource = content.slice(catchIndex, markerIndex);
+      if (
+        markerIndex >= 0 &&
+        catchIndex >= 0 &&
+        REQUIRED_PLUGIN_CLOUD_UNAVAILABLE_ERRORS.every(errorName =>
+          fallbackSource.includes(errorName)
+        )
+      ) {
         pluginFallbackPatchedSurfaces.add(key);
       }
     }


### PR DESCRIPTION
## Summary
- keep local and intranet plugin marketplaces usable when Windows reports online but Chromium blocks Internet access
- degrade only explicit Chromium transport failures on cloud catalog queries
- verify all five cloud surfaces, eight transport errors, legacy patch upgrades, and HTTP 503 propagation

## Verification
- node --test scripts/test/*.test.cjs (79 passed)
- node --test web-gateway/gateway/test/*.test.cjs (18 passed)
- npm --prefix web-gateway run build:gateway
- full Codex 26.803.5235.0 setup build and package verification
- 30-second offline direct-launch smoke test

## Release
- rebuild the existing offline-v26.803.5235.0 release with force_rebuild=true