### PR TITLE
fix: restore Codex 26.810 offline packaging and settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## 2026-08-13
+
+### 中文
+
+- 恢复最新版离线桌面设置中的“导入”和“连接”入口：共享能力契约跟进新的导入设置 gate，并重新启用本地桌面的远程连接 gate；配对、鉴权和网络错误仍沿用官方行为。
+- 离线包验证器现在会从当前 `import-settings-gate-*.js` 读取 gate ID，并在共享契约或桌面运行时未同步时阻止出包，避免上游 gate 漂移再次静默隐藏入口。
+
+### English
+
+- Restored the Import and Connections entries in the latest offline desktop settings. The shared capability contract now tracks the current import-settings gate and re-enables the local desktop remote-connections gates, while pairing, authentication, and network failures keep their upstream behavior.
+- Package verification now reads the gate ID from the current `import-settings-gate-*.js` chunk and blocks packaging when the shared contract or desktop runtime falls out of sync, preventing future upstream gate drift from silently hiding the entry.
+
+### Verification
+
+- Targeted offline UI and Gateway capability-contract tests
+- Gateway TypeScript build
+- Full script and Gateway regression suites
+- Current-bundle installer build and offline package verification
+
 ## 2026-08-12
 
 ### 中文

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,36 @@
 # Changelog
 
+## 2026-08-15
+
+### 中文
+
+- 修复 Codex `26.810.7004.0` 的 renderer 动态工具结构变化导致最新版离线包无法生成的问题。
+- Computer Use 的 `node_repl.js` 兼容补丁现在会保留新版 `deferLoading`、线程归属、实时委派和客户端协调守卫，仅补入顶层 namespace、无 namespace fallback 与调用桥；缺少必需 marker 时仍会阻止出包。
+- 归档设置兼容补丁现在识别新版带空列表守卫的 `isError` 别名，只保留本地归档查询错误，避免两个云端归档源在离线时隐藏已加载的本地会话。
+- Sidebar Activity priority surface 的权限状态读取器不再锁定单个压缩变量名，并继续由专用 marker 静态启用与验包。
+- Sky 0.6.11 的 tslib 路径缩短现在兼容 `dist/node_modules/.pnpm` 布局，重写 34 个导入并删除超过 Windows MAX_PATH 的依赖缓存路径。
+- Sky 缓存清理会在递归删除前拒绝根目录或子目录中的 NTFS reparse point，避免 `.pnpm` Junction 把删除范围带出 staging 目录。
+- Chrome `browser-client.mjs` 的环境读取补丁不再复用新版压缩函数参数名，并会修复旧构建缓存中已生成的 `function zn(t){let t=...}` 无效代码。
+- 离线包验证器在当前 import-settings gate chunk 缺失时改为直接失败，避免上游改名、合并或内联该 chunk 后静默放过入口回归。
+
+### English
+
+- Fixed the latest offline package build failing after Codex `26.810.7004.0` changed the renderer dynamic-tool structure.
+- The Computer Use `node_repl.js` compatibility patch now preserves the new `deferLoading`, thread-ownership, realtime-delegation, and client-coordination guards while adding only the top-level namespace, namespace-free fallback, and call bridge. Missing required markers still block packaging.
+- The archived-settings compatibility patch now recognizes the guarded `isError` alias, preserves only local archive-query failures, and prevents two offline cloud-source errors from hiding loaded local conversations.
+- The Sidebar Activity priority surface no longer pins its permission-status reader to one minified alias and remains statically enabled and verified through its dedicated marker.
+- Sky 0.6.11 tslib path shortening now supports the `dist/node_modules/.pnpm` layout, rewrites 34 imports, and removes the dependency-cache path that exceeds Windows MAX_PATH.
+- Sky cache cleanup now rejects NTFS reparse points in the cache root or descendants before recursive deletion, preventing a `.pnpm` junction from carrying deletion outside staging.
+- The Chrome `browser-client.mjs` ambient-network patch no longer reuses a minified function parameter and repairs invalid `function zn(t){let t=...}` output already present in cached exports.
+- Package verification now fails when the current import-settings gate chunk is missing, preventing an upstream rename, merge, or inline change from silently bypassing the settings-entry tripwire.
+
+### Verification
+
+- `node --test scripts/test/*.test.cjs web-gateway/gateway/test/*.test.cjs` (115/115 passed)
+- `npm --prefix web-gateway run build:gateway`
+- Full installer and portable package build for Codex `26.810.7004.0`
+- Offline package verification and 30-second direct-launch smoke test
+
 ## 2026-08-13
 
 ### 中文

--- a/docs/issue-59-gateway-vs-patch-analysis.md
+++ b/docs/issue-59-gateway-vs-patch-analysis.md
@@ -52,7 +52,7 @@ support Codex 26.616 bundle structure changes
 - **Layer 1**：`session.webRequest` 拦截 `ab.chatgpt.com/v1/initialize`，重定向为一个 `data:` URI，塞进伪造的 statsig 响应；
 - **Layer 0 / 2 / 3**：包装 `webContents.send` / `ipcMain.handle` / `ipcMain.on`，在 shared-object 快照流里注入 gate override。
 
-而它注入的 gate 列表，**已经包含了 `patch-app-asar.mjs` 里那些正则补丁所针对的同一批 gate ID**——36 个权威渲染层 gate ID（`DESKTOP_ASAR_KNOWN_GATE_IDS`）在 `init.cjs` 里逐个 `: true`：
+而它注入的 gate 列表，**已经包含了 `patch-app-asar.mjs` 里那些正则补丁所针对的同一批 gate ID**——44 个权威渲染层 gate ID（`DESKTOP_ASAR_KNOWN_GATE_IDS`）在 `init.cjs` 里逐个 `: true`：
 
 ```
 '3075919032': true,   // Automations
@@ -64,7 +64,7 @@ support Codex 26.616 bundle structure changes
 '1221508807': true,   // Background subagents
 '459748632':  true,   // Multi-window
 '2574306096': true,   // Chronicle
-... （共 36 个）
+... （共 44 个）
 ```
 
 也就是说，Patch 4、5、10–35 这批渲染层 gate needle，和 `init.cjs` 的运行时注入**在解决同一个问题**。仓库其实已经在往这个方向走——提交 `536b9c8 Refactor: replace renderer ASAR regex patches with IPC-level gate injection` 就是这次迁移的起点，`patch-app-asar.mjs` 头部的"加固原则"也白纸黑字写着：**优先在稳定接口边界（`process._linkedBinding`、`init.cjs` IPC 拦截）拦截，而不是字符串替换编译后的 token**。

--- a/docs/plan-b-patch-migration-inventory.md
+++ b/docs/plan-b-patch-migration-inventory.md
@@ -7,6 +7,12 @@
 > `scripts/patch-app-asar.mjs`、`scripts/desktop-patches/init.cjs`、
 > `web-gateway/gateway/src/ipc/codex/*`、`scripts/verify-offline-package.ps1`
 > 的静态审查；当前 `26.803.10989.0` 发布候选已经完成 Windows 端到端构建、包验证和桌面直接启动 smoke。
+>
+> 2026-08-13 兼容更新：当前 renderer 将独立的导入设置页切换到 gate
+> `3278809559`。该 ID 已进入共享能力契约和 `init.cjs`，包验证器会直接扫描
+> `import-settings-gate-*.js` 并校验实际 ID，后续上游换号时不再静默漏掉入口。
+> Remote Connections 的 `1042620455`/`4114442250` 也重新纳入共享契约；
+> 设置入口可见，但配对、鉴权和网络失败仍保持官方语义。
 
 ## 0. 一句话结论
 
@@ -79,6 +85,7 @@
 - Background Subagents `1221508807`、Thread Overlay `1060282072`、Multi-Window `459748632`
 - Computer Use gate `1506311413`、Control `2171042036`、Dictation `1244621283`/`4100906017`
 - Thread Hover Cards `3032432888`、Chronicle `2574306096`、Personality `1444479692`
+- Import Settings 当前 gate `3278809559`（旧版 External Agent Config 仍兼容 `3326157269`/`2900529421`/`2711149772`/`816842483`）
 - Remote Connections `1042620455`/`4114442250`、Artifact Electron `839469903`
 - fast-mode 旧版选择器 REs（`FAST_MODE_GATE_RE`/`FAST_MODE_AVAILABILITY_RE`/`FAST_MODE_SERVICE_TIER_GET_RE`/`_OPTIONS_RE`/`_FAST_TIER_RE`，被 §2A 的 service-tier 方案取代）
 - context-usage 旧 REs（`CONTEXT_USAGE_STATUS_SECTION_FALSE_RE`/`_TRUE_RE`/`_PATCHED_RE`，marker 本体仍 USED，仅这几个 RE 死）
@@ -97,7 +104,7 @@
 | Plugins API-key nav | `PLUGINS_API_KEY_NAV_PATCH_MARKER` (行3621) | `if (hasPluginsApiKeyDisabledNavBranch && !pluginsApiKeyNavPatched)` (行1408) | 休眠：当前 bundle 无该分支，条件为假，构建通过 |
 | Plugins API-key route | `PLUGINS_API_KEY_ROUTE_PATCH_MARKER` (行3623) | 行1420 | 同上 |
 | Codex Mobile auth relogin | `CODEX_MOBILE_AUTH_RELOGIN_PATCH_MARKER` (行3770) | `if (codexMobileRemoteControlMfaEndpointSeen && !codexMobileAuthReloginPatched)` (行1468) | 同上 |
-| External agent config import | `EXTERNAL_AGENT_CONFIG_GATE_IDS`(行3606,唯一 LIVE)/`_MARKERS`(行3612) | 无硬断言（gate id 已在 init.cjs） | 孤儿，`GATE_IDS`→`MARKERS` 自引用后即断 |
+| External agent config import | 旧版 `EXTERNAL_AGENT_CONFIG_GATE_IDS`/`_MARKERS` helper | 当前 `import-settings-gate-*.js` 的实际 ID 必须存在于共享契约、ASAR gate 清单和 required markers | 旧 helper 仍是孤儿；当前入口由共享契约处理，并有出包 tripwire |
 
 **风险**：这些补丁的 apply 逻辑已经不在了。一旦 upstream 重新引入对应分支，verify
 条件变真、marker 未注入 → **构建会 fail，且脚本里已无对应 apply 代码可修**。也就是说

--- a/docs/plan-b-patch-migration-inventory.md
+++ b/docs/plan-b-patch-migration-inventory.md
@@ -13,6 +13,26 @@
 > `import-settings-gate-*.js` 并校验实际 ID，后续上游换号时不再静默漏掉入口。
 > Remote Connections 的 `1042620455`/`4114442250` 也重新纳入共享契约；
 > 设置入口可见，但配对、鉴权和网络失败仍保持官方语义。
+>
+> 2026-08-15 兼容更新：Store `26.810.7004.0` 扩展了 renderer 动态工具的
+> `deferLoading` 条件，并在调用执行权声明前加入线程归属、实时委派和客户端协调守卫。
+> `node_repl.js` 补丁继续属于无法下沉到 Gateway 的 renderer 动态工具边界；当前实现
+> 原样保留这些上游守卫，只补入顶层 namespace、无 namespace fallback 和调用桥，
+> 最终 ASAR 验证器仍要求两个既有 marker。
+> 同版的归档设置面板还把 `isError` 改为带空列表守卫的三来源别名；兼容补丁
+> 保留该守卫和本地 `list-archived-threads` 错误，只移除离线必失败的两个云端
+> 归档源错误，并继续使用既有 marker 与验包规则。
+> Sidebar Activity 的权限状态读取器也从 `q(...)` 改为新的压缩别名；补丁与验包器
+> 现在绑定稳定的 gate ID、返回状态形态和专用 marker，而不再绑定该临时别名。
+> 同时，内置 Sky 0.6.11 将 tslib 从 `js-dependency-cache` 移到
+> `dist/node_modules/.pnpm`；构建器现在兼容两种布局，统一复制到 `dist/js-deps`、
+> 重写导入并移除长缓存路径，验包器同步拒绝两种残留。递归移除缓存前还会
+> 拒绝根目录或后代中的 NTFS reparse point，避免 `.pnpm` Junction 越过 staging
+> 边界。当前 import-settings gate chunk 若完全缺失，验包器也会 fail closed，
+> 不再把改名、合并或内联造成的 gate 漂移当作“无须检查”。
+> Chrome `browser-client.mjs` 的 scoped 环境读取器在该版把参数压缩为 `t`，旧补丁
+> 再插入 `let t` 后会生成语法无效的重复声明。当前补丁使用独立局部变量，并在再次
+> 处理旧 source cache 时定向迁移已生成的无效代码；系统 Node 与内置 Node 均参与语法验证。
 
 ## 0. 一句话结论
 

--- a/docs/plan-b-patch-migration-inventory.md
+++ b/docs/plan-b-patch-migration-inventory.md
@@ -167,7 +167,7 @@ statsig store 之外的第二处读取。桌面侧由 `patchDirectStatsigGateCal
   `DESKTOP_ASAR_PATCH_MARKERS` 与 verify 条件断言中。
 - Stage 3 一致性断言已实施：新增 `scripts/check-gate-override-sync.mjs`，断言
   `DESKTOP_ASAR_KNOWN_GATE_IDS` 与 `init.cjs` `STATSIG_GATE_OVERRIDES` 的数字
-  gate id 集合相等（当前 36 = 36）。已挂进 `build-offline-package.ps1`（patch 前）
+  gate id 集合相等（当前 44 = 44）。已挂进 `build-offline-package.ps1`（patch 前）
   与 `patch-app-asar.mjs`（动 asar 前 fail-fast）。任一边加漏 gate → 构建 exit 1
   并点名缺失 id。
 - 验证覆盖：三文件 `node --check` 通过；死常量引用归零；一致性断言正/反用例均验证；

--- a/scripts/build-offline-package.ps1
+++ b/scripts/build-offline-package.ps1
@@ -567,13 +567,22 @@ function Shorten-SkyTslibDependencyPath {
     param([Parameter(Mandatory = $true)][string]$CuaNodeRoot)
 
     $skyDistRoot = Join-Path $CuaNodeRoot 'bin/node_modules/@oai/sky/dist'
-    $cacheRoot = Join-Path $skyDistRoot 'js-dependency-cache'
-    if (-not (Test-Path -LiteralPath $cacheRoot -PathType Container)) {
+    $cacheRoots = @(
+        foreach ($relativeCacheRoot in @('js-dependency-cache', 'node_modules/.pnpm')) {
+            $candidate = Join-Path $skyDistRoot $relativeCacheRoot
+            if (Test-Path -LiteralPath $candidate -PathType Container) {
+                $candidate
+            }
+        }
+    )
+    if ($cacheRoots.Count -eq 0) {
         return 0
     }
 
     $cachedTslibFiles = @(
-        Get-ChildItem -LiteralPath $cacheRoot -Recurse -File -Filter 'tslib.es6.js'
+        foreach ($cacheRoot in $cacheRoots) {
+            Get-ChildItem -LiteralPath $cacheRoot -Recurse -File -Filter 'tslib.es6.js'
+        }
     )
     if ($cachedTslibFiles.Count -ne 1) {
         throw "Expected exactly one cached Sky tslib.es6.js, found $($cachedTslibFiles.Count)."
@@ -589,7 +598,7 @@ function Shorten-SkyTslibDependencyPath {
         $source = Get-Content -LiteralPath $jsFile.FullName -Raw
         $matches = @([regex]::Matches(
             $source,
-            '[^"'']*js-dependency-cache[^"'']*tslib/tslib\.es6\.js'
+            '[^"'']*(?:js-dependency-cache|node_modules/\.pnpm)[^"'']*tslib/tslib\.es6\.js'
         ))
         if ($matches.Count -eq 0) {
             continue
@@ -610,12 +619,24 @@ function Shorten-SkyTslibDependencyPath {
         throw 'Sky tslib cache exists but no JavaScript imports reference it.'
     }
 
-    $resolvedCacheRoot = [System.IO.Path]::GetFullPath($cacheRoot)
     $resolvedSkyDistRoot = [System.IO.Path]::GetFullPath($skyDistRoot) + [System.IO.Path]::DirectorySeparatorChar
-    if (-not $resolvedCacheRoot.StartsWith($resolvedSkyDistRoot, [System.StringComparison]::OrdinalIgnoreCase)) {
-        throw "Refusing to remove Sky cache outside its dist directory: $resolvedCacheRoot"
+    foreach ($cacheRoot in $cacheRoots) {
+        $resolvedCacheRoot = [System.IO.Path]::GetFullPath($cacheRoot)
+        if (-not $resolvedCacheRoot.StartsWith($resolvedSkyDistRoot, [System.StringComparison]::OrdinalIgnoreCase)) {
+            throw "Refusing to remove Sky cache outside its dist directory: $resolvedCacheRoot"
+        }
+        $cacheRootItem = Get-Item -LiteralPath $resolvedCacheRoot -Force
+        if (($cacheRootItem.Attributes -band [System.IO.FileAttributes]::ReparsePoint) -ne 0) {
+            throw "Refusing to recursively remove Sky cache reparse point: $resolvedCacheRoot"
+        }
+        $nestedReparsePoint = Get-ChildItem -LiteralPath $resolvedCacheRoot -Force -Recurse |
+            Where-Object { ($_.Attributes -band [System.IO.FileAttributes]::ReparsePoint) -ne 0 } |
+            Select-Object -First 1
+        if ($null -ne $nestedReparsePoint) {
+            throw "Refusing to recursively remove Sky cache containing reparse point: $($nestedReparsePoint.FullName)"
+        }
+        Remove-Item -LiteralPath $resolvedCacheRoot -Recurse -Force
     }
-    Remove-Item -LiteralPath $resolvedCacheRoot -Recurse -Force
 
     return $referenceCount
 }

--- a/scripts/desktop-patches/init.cjs
+++ b/scripts/desktop-patches/init.cjs
@@ -200,6 +200,7 @@
     '2900529421': true,   // External agent config
     '2711149772': true,   // External agent config
     '816842483': true,    // External agent config
+    '3278809559': true,   // Import settings page (26.803.81509+)
     guardian_approval: true,
     fast_mode: true,
     browserPane: true,
@@ -234,6 +235,8 @@
     '2574306096': true,   // Chronicle
     '1444479692': true,   // Agent personality
     '717035860': true,    // Sidebar customization and destination discovery
+    '1042620455': true,   // Remote connections
+    '4114442250': true,   // Remote connections feature flag
     '839469903': true,    // Artifact Electron native
   };
 

--- a/scripts/patch-app-asar.mjs
+++ b/scripts/patch-app-asar.mjs
@@ -818,11 +818,11 @@ function patchSidebarActivitySurface(content) {
   let patched = false;
   const sidebarPatchedSurfaceRe = new RegExp(
     `([A-Za-z_$][\\w$]*)=!0${escapeRegExp(SIDEBAR_ACTIVITY_VIEW_PATCH_MARKER)},` +
-      `([A-Za-z_$][\\w$]*)=q\\([A-Za-z_$][\\w$]*\\);return \\1&&` +
+      `([A-Za-z_$][\\w$]*)=[A-Za-z_$][\\w$]*\\([A-Za-z_$][\\w$]*\\);return \\1&&` +
       '\\(\\2\\.status===`allowed`\\|\\|\\2\\.status===`loading`\\)',
   );
   const sidebarUnpatchedSurfaceRe =
-    /([A-Za-z_$][\w$]*)=([A-Za-z_$][\w$]*)\(([A-Za-z_$][\w$]*)\),([A-Za-z_$][\w$]*)=q\([A-Za-z_$][\w$]*\);return \1&&\(\4\.status===`allowed`\|\|\4\.status===`loading`\)\}[^]*?\3=`4039078146`/;
+    /([A-Za-z_$][\w$]*)=([A-Za-z_$][\w$]*)\(([A-Za-z_$][\w$]*)\),([A-Za-z_$][\w$]*)=[A-Za-z_$][\w$]*\([A-Za-z_$][\w$]*\);return \1&&\(\4\.status===`allowed`\|\|\4\.status===`loading`\)\}[^]*?\3=`4039078146`/;
   const sidebarAlreadyCorrect = sidebarPatchedSurfaceRe.test(next);
   const sidebarSurfaceSeen =
     sidebarAlreadyCorrect ||
@@ -1534,6 +1534,17 @@ function patchChromeBrowserClient(filePath) {
 
   const ambientNetworkPatchMarker =
     '/*codex-offline:browser-use-disable-ambient-network-default*/';
+  const staleScopedAmbientNetworkPatchRe =
+    /function ([A-Za-z_$][\w$]*)\(([A-Za-z_$][\w$]*)\)\{let \2=([A-Za-z_$][\w$]*)\(\2,([A-Za-z_$][\w$]*)\);return \2==="0"\|\|\2==="false"\?!1:!0\}\/\*codex-offline:browser-use-disable-ambient-network-default\*\//;
+  if (staleScopedAmbientNetworkPatchRe.test(content)) {
+    content = content.replace(
+      staleScopedAmbientNetworkPatchRe,
+      (_match, functionName, parameterName, rawReader, ambientEnvVar) =>
+        `function ${functionName}(${parameterName}){let _codexOfflineAmbientNetworkValue=${rawReader}(${parameterName},${ambientEnvVar});return _codexOfflineAmbientNetworkValue==="0"||_codexOfflineAmbientNetworkValue==="false"?!1:!0}${ambientNetworkPatchMarker}`,
+    );
+    changed = true;
+    log('Repaired cached Chrome browser client ambient network patch.');
+  }
   if (content.includes(ambientNetworkPatchMarker)) {
     log('Chrome browser client ambient network default already patched.');
   } else {
@@ -1593,7 +1604,7 @@ function patchChromeBrowserClient(filePath) {
       if (scopedEnvGuardMatch && scopedRawReaderMatch && ambientEnvVar) {
         ambientNetworkNeedle = scopedEnvGuardMatch[0];
         ambientNetworkReplacement =
-          `function ${scopedEnvGuardMatch[1]}(${scopedEnvGuardMatch[2]}){let t=${scopedRawReaderMatch[3]}(${scopedEnvGuardMatch[2]},${ambientEnvVar});return t==="0"||t==="false"?!1:!0}${ambientNetworkPatchMarker}`;
+          `function ${scopedEnvGuardMatch[1]}(${scopedEnvGuardMatch[2]}){let _codexOfflineAmbientNetworkValue=${scopedRawReaderMatch[3]}(${scopedEnvGuardMatch[2]},${ambientEnvVar});return _codexOfflineAmbientNetworkValue==="0"||_codexOfflineAmbientNetworkValue==="false"?!1:!0}${ambientNetworkPatchMarker}`;
       } else if (envGuardMatch && rawReader && ambientEnvVar) {
         ambientNetworkNeedle = envGuardMatch[0];
         ambientNetworkReplacement =
@@ -2480,7 +2491,7 @@ try {
   const COMPUTER_USE_NODE_REPL_DYNAMIC_TOOLS_TOP_LEVEL_RE =
     /\]\.map\((?<item>[A-Za-z_$][\w$]*)=>\(\{type:`function`,\.\.\.\k<item>,\.\.\.(?<eager>[A-Za-z_$][\w$]*)\.has\(\k<item>\.name\)\?\{\}:\{deferLoading:!0\}\}\)\);return (?<supportsNamespaces>[A-Za-z_$][\w$]*)\?\[\{type:`namespace`,name:(?<appNamespace>[A-Za-z_$][\w$]*),description:`Tools provided by the Codex app\.`,tools:(?<functionTools>[A-Za-z_$][\w$]*)\},\.\.\.(?<namespaceGroups>[A-Za-z_$][\w$]*)\]:\k<functionTools>/;
   const COMPUTER_USE_NODE_REPL_DYNAMIC_TOOLS_TOP_LEVEL_CURRENT_RE =
-    /\]\.map\((?<item>[A-Za-z_$][\w$]*)=>\(\{type:`function`,\.\.\.\k<item>,\.\.\.(?<supportsNamespaces>[A-Za-z_$][\w$]*)&&!(?<eager>[A-Za-z_$][\w$]*)\.has\(\k<item>\.name\)\?\{deferLoading:!0\}:\{\}\}\)\);return \k<supportsNamespaces>\?\[\{type:`namespace`,name:(?<appNamespace>[A-Za-z_$][\w$]*),description:`Tools provided by the Codex app\.`,tools:(?<functionTools>[A-Za-z_$][\w$]*)\},\.\.\.(?<namespaceGroups>[A-Za-z_$][\w$]*)\]:(?<fallbackTools>[A-Za-z_$][\w$]*)/;
+    /\]\.map\((?<item>[A-Za-z_$][\w$]*)=>\(\{type:`function`,\.\.\.\k<item>,\.\.\.(?<deferLoadingGuard>(?<supportsNamespaces>[A-Za-z_$][\w$]*)&&[^?]+)\?\{deferLoading:!0\}:\{\}\}\)\);return \k<supportsNamespaces>\?\[\{type:`namespace`,name:(?<appNamespace>[A-Za-z_$][\w$]*),description:`Tools provided by the Codex app\.`,tools:(?<functionTools>[A-Za-z_$][\w$]*)\},\.\.\.(?<namespaceGroups>[A-Za-z_$][\w$]*)\]:(?<fallbackTools>[A-Za-z_$][\w$]*)/;
   const COMPUTER_USE_NODE_REPL_DYNAMIC_TOOL_COMPAT_MISSING_RE =
     /(\(\{namespace:`node_repl`,name:`js`,description:`Execute JavaScript in the persistent Node REPL used by Computer Use\.`,inputSchema:\{[\s\S]{0,700}?required:\[`code`\]\}\}\),)(?!\(\{name:`js`,description:`Execute JavaScript in the persistent Node REPL used by Computer Use\. This forwards to node_repl\.js\.`)/;
   const COMPUTER_USE_NODE_REPL_DYNAMIC_TOOL_CALL_RE =
@@ -2492,7 +2503,7 @@ try {
   const COMPUTER_USE_NODE_REPL_DYNAMIC_TOOL_CALL_CURRENT_V3_RE =
     /(?<prefix>async function [A-Za-z_$][\w$]*\(\{scope:(?<scope>[A-Za-z_$][\w$]*),serverRequest:(?<serverRequest>[A-Za-z_$][\w$]*),hostId:(?<hostId>[A-Za-z_$][\w$]*),queryClient:(?<queryClient>[A-Za-z_$][\w$]*)\}\)\{let\{id:(?<requestId>[A-Za-z_$][\w$]*),params:(?<params>[A-Za-z_$][\w$]*)\}=\k<serverRequest>,\{threadId:(?<threadId>[A-Za-z_$][\w$]*),tool:(?<tool>[A-Za-z_$][\w$]*)\}=\k<params>;if\(!\k<threadId>\)\{(?<logger>[A-Za-z_$][\w$]*)\.error\(`Missing threadId for dynamic tool call request`,\{safe:\{\},sensitive:\{id:\k<requestId>,params:\k<params>\}\}\);return\}let (?<result>[A-Za-z_$][\w$]*),(?<namespaceOk>[A-Za-z_$][\w$]*)=\k<params>\.namespace===[^,;]+,(?<compatOk>[A-Za-z_$][\w$]*)=\k<params>\.namespace==null&&[^;]+;)(?<gate>if\([A-Za-z_$][\w$]*!=null\)\k<result>=[A-Za-z_$][\w$]*;else if\(!\k<namespaceOk>&&!\k<compatOk>\)\k<result>=(?<failureFn>[A-Za-z_$][\w$]*)\(`Unsupported dynamic tool namespace: \$\{\k<params>\.namespace\}`\);else)/;
   const COMPUTER_USE_NODE_REPL_DYNAMIC_TOOL_CALL_CURRENT_V4_RE =
-    /(?<prefix>async function [A-Za-z_$][\w$]*\(\{scope:(?<scope>[A-Za-z_$][\w$]*),serverRequest:(?<serverRequest>[A-Za-z_$][\w$]*),hostId:(?<hostId>[A-Za-z_$][\w$]*),queryClient:(?<queryClient>[A-Za-z_$][\w$]*)\}\)\{let\{id:(?<requestId>[A-Za-z_$][\w$]*),params:(?<params>[A-Za-z_$][\w$]*)\}=\k<serverRequest>,\{threadId:(?<threadId>[A-Za-z_$][\w$]*),tool:(?<tool>[A-Za-z_$][\w$]*)\}=\k<params>;if\(!\k<threadId>\)\{(?<logger>[A-Za-z_$][\w$]*)\.error\(`Missing threadId for dynamic tool call request`,\{safe:\{\},sensitive:\{id:\k<requestId>,params:\k<params>\}\}\);return\}if\([A-Za-z_$][\w$]*\.dynamicToolCalls!=null&&!await [A-Za-z_$][\w$]*\.dynamicToolCalls\.tryClaimExecution\(\{callId:\k<params>\.callId,hostId:\k<hostId>,threadId:\k<threadId>,turnId:\k<params>\.turnId\}\)\)return;let (?<result>[A-Za-z_$][\w$]*),(?<namespaceOk>[A-Za-z_$][\w$]*)=\k<params>\.namespace===[^,;]+,(?<compatOk>[A-Za-z_$][\w$]*)=\k<params>\.namespace==null&&[^,;]+,(?<dynamicResult>[A-Za-z_$][\w$]*)=[^,;]+\?await [^;]+:null,(?<pluginResult>[A-Za-z_$][\w$]*)=\k<params>\.namespace===`plugin_management`\?await [^;]+:null;)(?<gate>if\(\k<pluginResult>!=null\)\k<result>=\k<pluginResult>;else if\(!\k<namespaceOk>&&!\k<compatOk>\)\k<result>=(?<failureFn>[A-Za-z_$][\w$]*)\(`Unsupported dynamic tool namespace: \$\{\k<params>\.namespace\}`\);else if\(\k<dynamicResult>!=null\)\k<result>=\k<dynamicResult>;else)/;
+    /(?<prefix>async function [A-Za-z_$][\w$]*\(\{scope:(?<scope>[A-Za-z_$][\w$]*),serverRequest:(?<serverRequest>[A-Za-z_$][\w$]*),hostId:(?<hostId>[A-Za-z_$][\w$]*),queryClient:(?<queryClient>[A-Za-z_$][\w$]*)\}\)\{let\{id:(?<requestId>[A-Za-z_$][\w$]*),params:(?<params>[A-Za-z_$][\w$]*)\}=\k<serverRequest>,\{threadId:(?<threadId>[A-Za-z_$][\w$]*),tool:(?<tool>[A-Za-z_$][\w$]*)\}=\k<params>;if\(!\k<threadId>\)\{(?<logger>[A-Za-z_$][\w$]*)\.error\(`Missing threadId for dynamic tool call request`,\{safe:\{\},sensitive:\{id:\k<requestId>,params:\k<params>\}\}\);return\}(?<preClaimGuards>[\s\S]{0,900}?)if\([A-Za-z_$][\w$]*\.dynamicToolCalls!=null&&!await [A-Za-z_$][\w$]*\.dynamicToolCalls\.tryClaimExecution\(\{callId:\k<params>\.callId,hostId:\k<hostId>,threadId:\k<threadId>,turnId:\k<params>\.turnId\}\)\)return;let (?<result>[A-Za-z_$][\w$]*),(?<namespaceOk>[A-Za-z_$][\w$]*)=\k<params>\.namespace===[^,;]+,(?<compatOk>[A-Za-z_$][\w$]*)=\k<params>\.namespace==null&&[^,;]+,(?<dynamicResult>[A-Za-z_$][\w$]*)=[^,;]+\?await [^;]+:null,(?<pluginResult>[A-Za-z_$][\w$]*)=(?:\k<params>\.namespace===`plugin_management`(?:\|\|\k<params>\.namespace===`openai_settings\`)?)\?await [^;]+:null;)(?<gate>if\(\k<pluginResult>!=null\)\k<result>=\k<pluginResult>;else if\(!\k<namespaceOk>&&!\k<compatOk>\)\k<result>=(?<failureFn>[A-Za-z_$][\w$]*)\(`Unsupported dynamic tool namespace: \$\{\k<params>\.namespace\}`\);else if\(\k<dynamicResult>!=null\)\k<result>=\k<dynamicResult>;else)/;
   const COMPUTER_USE_NODE_REPL_RESULT_TEXT_CODE =
     'let _codexOfflineNodeReplStringify=e=>{try{return JSON.stringify(e)}catch{return String(e)}};' +
     'let _codexOfflineNodeReplContentText=e=>Array.isArray(e)?e.map(e=>(e?.type===`text`||e?.type===`inputText`)?String(e.text??``):e?.text!=null?String(e.text):_codexOfflineNodeReplStringify(e)).join(`\\n`):``;' +
@@ -2600,7 +2611,7 @@ try {
   function computerUseNodeReplDynamicToolsTopLevelCurrentReplacement(...args) {
     const {
       item,
-      eager,
+      deferLoadingGuard,
       supportsNamespaces,
       appNamespace,
       functionTools,
@@ -2609,7 +2620,7 @@ try {
     } = args.at(-1);
     return (
       `].map(${item}=>({type:\`function\`,...${item},` +
-      `...${supportsNamespaces}&&!${eager}.has(${item}.name)?{deferLoading:!0}:{}}));` +
+      `...${deferLoadingGuard}?{deferLoading:!0}:{}}));` +
       `return ${supportsNamespaces}?[{type:\`namespace\`,name:${appNamespace},` +
       `description:\`Tools provided by the Codex app.\`,tools:${functionTools}},` +
       `...${namespaceGroups},${COMPUTER_USE_NODE_REPL_NAMESPACE_GROUP_SPEC}]` +
@@ -2907,11 +2918,10 @@ try {
     return { content: next, alreadyCorrect: false, patched: next !== content };
   }
   // The archived settings panel (Settings → Data controls → Archived) combines
-  // the LOCAL archived-thread query error with a CLOUD tasks query error into a
-  // single isError prop: `<isErr>=<localErr>||<cloudData>==null&&<cloudErr>`. The
-  // cloud query hits /wham/tasks/list, so while OFFLINE it always fails, forcing
-  // the whole panel into its error state and hiding the perfectly good local
-  // archived conversations. Drop the cloud term so local archived chats still
+  // the LOCAL archived-thread query error with CLOUD archive-source errors into
+  // one isError prop. Those network queries fail while OFFLINE, forcing the whole
+  // panel into its error state and hiding the perfectly good local archived
+  // conversations. Drop the cloud terms so local archived chats still
   // render offline; a genuine local query failure (localErr) still shows the
   // error state. Root cause of issue #55's "archived disappears when offline".
   function patchArchivedSettingsOfflineVisibility(content) {
@@ -2930,6 +2940,29 @@ try {
       .match(/isError:([A-Za-z_$][\w$]*),onLoadNextPage:/);
     if (isErrorPropMatch) {
       const isErrorVar = isErrorPropMatch[1];
+      const currentAliasedErrorRe = new RegExp(
+        '(^|[^\\w$])(' +
+          isErrorVar +
+          ')=([A-Za-z_$][\\w$]*)\\.length===0&&\\((' +
+          '[A-Za-z_$][\\w$]*)&&([A-Za-z_$][\\w$]*)\\|\\|' +
+          '[A-Za-z_$][\\w$]*==null&&[A-Za-z_$][\\w$]*\\|\\|' +
+          '[A-Za-z_$][\\w$]*&&[A-Za-z_$][\\w$]*==null&&[A-Za-z_$][\\w$]*\\)(?=[,;)])',
+      );
+      if (currentAliasedErrorRe.test(content)) {
+        const next = content
+          .replace(
+            currentAliasedErrorRe,
+            (_match, prefix, errorVar, itemsVar, localAvailableVar, localErrorVar) =>
+              `${prefix}${errorVar}=${itemsVar}.length===0&&${localAvailableVar}&&${localErrorVar}`,
+          )
+          .replace(
+            `isError:${isErrorVar},onLoadNextPage:`,
+            `isError:${isErrorVar}${ARCHIVED_SETTINGS_OFFLINE_LOCAL_VISIBILITY_PATCH_MARKER},onLoadNextPage:`,
+          );
+        if (next !== content) {
+          return { content: next, alreadyCorrect: false, patched: true };
+        }
+      }
       const combinedErrorRe = new RegExp(
         '(^|[^\\w$])(' + isErrorVar + ')=([A-Za-z_$][\\w$]*)\\|\\|' +
           '[A-Za-z_$][\\w$]*==null&&[A-Za-z_$][\\w$]*(?=[,;)])',

--- a/scripts/test/current-bundle-compatibility.test.cjs
+++ b/scripts/test/current-bundle-compatibility.test.cjs
@@ -89,6 +89,10 @@ test("26.727 archive verifier accepts the current isError prop layout", () => {
     true,
   );
   assert.equal(
+    isVerified(`archivedChats:H,isError:_e${marker},onLoadNextPage:G`, marker),
+    true,
+  );
+  assert.equal(
     isVerified("archivedChats:foo,isError:t&&l,onLoadNextPage:d", marker),
     false,
   );
@@ -200,6 +204,101 @@ test("26.803 Chrome ambient network default accepts runtime-scoped env readers",
   assert.equal(result.ambientEnvVarMatch?.[1], "Jy");
   assert.equal(result.scopedEnvGuardMatch?.[1], "qn");
   assert.equal(result.scopedRawReaderMatch?.[3], "_s");
+});
+
+test("26.810 Chrome ambient network patch avoids minified parameter collisions", () => {
+  const patchSource = sourceSlice(
+    "    const requestMetaAmbientNetworkMatch =",
+    "\n    if (!ambientNetworkNeedle || !ambientNetworkReplacement)",
+  );
+  const patchAmbientNetwork = Function(
+    "content",
+    "escapeRegExp",
+    "ambientNetworkPatchMarker",
+    `"use strict";\n${patchSource}\nreturn { ambientNetworkNeedle, ambientNetworkReplacement };`,
+  );
+  const fixture =
+    'var fw="BROWSER_USE_DISABLE_AMBIENT_NETWORK";' +
+    'function $r(e,t){return Ts(e,t)==="1"}' +
+    'function zn(t){return $r(t,fw)}';
+
+  const result = patchAmbientNetwork(
+    fixture,
+    value => value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"),
+    "/*codex-offline:browser-use-disable-ambient-network-default*/",
+  );
+  const patchedFixture = fixture.replace(
+    result.ambientNetworkNeedle,
+    result.ambientNetworkReplacement,
+  );
+
+  assert.doesNotThrow(() => Function(patchedFixture));
+  assert.match(patchedFixture, /function zn\(t\)\{let _codexOfflineAmbientNetworkValue=/);
+});
+
+test("26.810 Chrome ambient network patch repairs cached invalid output", () => {
+  const migrationSource = sourceSlice(
+    "  const staleScopedAmbientNetworkPatchRe =",
+    "\n  if (content.includes(ambientNetworkPatchMarker))",
+  );
+  const migrateAmbientNetwork = Function(
+    "content",
+    "ambientNetworkPatchMarker",
+    "log",
+    `"use strict";\nlet changed = false;\n${migrationSource}\nreturn { content, changed };`,
+  );
+  const fixture =
+    'var fw="BROWSER_USE_DISABLE_AMBIENT_NETWORK";' +
+    'function Ts(e,t){return process.env[t]}' +
+    'function zn(t){let t=Ts(t,fw);return t==="0"||t==="false"?!1:!0}' +
+    "/*codex-offline:browser-use-disable-ambient-network-default*/";
+
+  const result = migrateAmbientNetwork(
+    fixture,
+    "/*codex-offline:browser-use-disable-ambient-network-default*/",
+    () => {},
+  );
+
+  assert.equal(result.changed, true);
+  assert.doesNotThrow(() => Function(result.content));
+  assert.match(result.content, /function zn\(t\)\{let _codexOfflineAmbientNetworkValue=/);
+});
+
+test("P1 release guard rejects Sky tslib cache roots that contain junctions before recursive deletion", () => {
+  const functionStart = buildScriptSource.indexOf("function Shorten-SkyTslibDependencyPath {");
+  const functionEnd = buildScriptSource.indexOf("\n\n$scriptRoot =", functionStart);
+  assert.notEqual(functionStart, -1, "Shorten-SkyTslibDependencyPath is missing");
+  assert.notEqual(functionEnd, -1, "Shorten-SkyTslibDependencyPath terminator is missing");
+
+  const helperSource = buildScriptSource.slice(functionStart, functionEnd);
+  const removeIndex = helperSource.indexOf("Remove-Item -LiteralPath $resolvedCacheRoot -Recurse -Force");
+  assert.notEqual(removeIndex, -1, "Sky tslib cache removal is missing");
+
+  const reparseGuardIndex = helperSource.search(
+    /Get-Item -LiteralPath \$resolvedCacheRoot[\s\S]*?ReparsePoint[\s\S]*?throw/i,
+  );
+  assert.notEqual(
+    reparseGuardIndex,
+    -1,
+    "cache root itself must fail-closed when it is a reparse point",
+  );
+  assert.ok(
+    reparseGuardIndex < removeIndex,
+    "cache root reparse-point guard must run before recursive deletion",
+  );
+
+  const descendantGuardIndex = helperSource.search(
+    /Get-ChildItem -LiteralPath \$resolvedCacheRoot[\s\S]*?-Recurse[\s\S]*?ReparsePoint[\s\S]*?throw/i,
+  );
+  assert.notEqual(
+    descendantGuardIndex,
+    -1,
+    "cache descendants must fail-closed when a nested reparse point is present",
+  );
+  assert.ok(
+    descendantGuardIndex < removeIndex,
+    "descendant reparse-point guard must run before recursive deletion",
+  );
 });
 
 test("26.721 Computer Use accepts resource-based Windows runtime paths", () => {
@@ -402,6 +501,39 @@ test("26.727 dynamic tools keep node_repl at the top-level namespace boundary", 
   assert.match(patched, /:A\.concat\(\[\{type:`function`,name:`js`/);
 });
 
+test("26.810 dynamic tools keep node_repl at the top-level namespace boundary with guarded deferLoading", () => {
+  const regexSource = sourceSlice(
+    "  const COMPUTER_USE_NODE_REPL_DYNAMIC_TOOLS_TOP_LEVEL_CURRENT_RE =",
+    "\n  const COMPUTER_USE_NODE_REPL_DYNAMIC_TOOL_CALL_RE =",
+  );
+  const currentRegex = Function(
+    `"use strict";\n${regexSource}\nreturn COMPUTER_USE_NODE_REPL_DYNAMIC_TOOLS_TOP_LEVEL_CURRENT_RE;`,
+  )();
+  const replacementSource = sourceSlice(
+    "  function computerUseNodeReplDynamicToolsTopLevelCurrentReplacement(",
+    "\n  function patchComputerUseNodeReplDynamicTools(",
+  );
+  const replacement = Function(
+    "COMPUTER_USE_NODE_REPL_NAMESPACE_GROUP_SPEC",
+    "COMPUTER_USE_NODE_REPL_NAMESPACE_TOOL_SPEC",
+    "COMPUTER_USE_NODE_REPL_DYNAMIC_TOOL_PATCH_MARKER",
+    `"use strict";\n${replacementSource}\nreturn computerUseNodeReplDynamicToolsTopLevelCurrentReplacement;`,
+  )(
+    "{type:`namespace`,name:`node_repl`,description:`Node REPL tools for Computer Use.`,tools:[{type:`function`,name:`js`}]}",
+    "{type:`function`,name:`js`}",
+    "/*codex-offline:computer-use-node-repl-dynamic-tool*/",
+  );
+  const fixture =
+    "].map(e=>({type:`function`,...e,...E&&(!zzl.has(e.name)||o&&Azl.includes(e.name))?{deferLoading:!0}:{}}));" +
+    "return E?[{type:`namespace`,name:Rzl,description:`Tools provided by the Codex app.`,tools:I},...M]:I";
+
+  const patched = fixture.replace(currentRegex, replacement);
+  assert.notEqual(patched, fixture);
+  assert.ok(patched.includes("/*codex-offline:computer-use-node-repl-dynamic-tool*/"));
+  assert.match(patched, /\.\.\.M,\{type:`namespace`,name:`node_repl`/);
+  assert.match(patched, /:I\.concat\(\[\{type:`function`,name:`js`/);
+});
+
 test("26.727 archived settings keeps local errors separate from cloud task errors", () => {
   const patchSource = sourceSlice(
     "  function patchArchivedSettingsOfflineVisibility(content) {",
@@ -422,6 +554,31 @@ test("26.727 archived settings keeps local errors separate from cloud task error
     /isError:t&&l\/\*codex-offline:archived-settings-offline-local-visibility\*\//,
   );
   assert.ok(!result.content.includes("u==null&&g"));
+});
+
+test("26.810 archived settings ignores both cloud archive errors offline", () => {
+  const patchSource = sourceSlice(
+    "  function patchArchivedSettingsOfflineVisibility(content) {",
+    "\n  const COMPUTER_USE_NODE_REPL_DYNAMIC_TOOL_CALL_LEGACY_RE =",
+  );
+  const patchArchivedSettingsOfflineVisibility = Function(
+    "ARCHIVED_SETTINGS_OFFLINE_LOCAL_VISIBILITY_PATCH_MARKER",
+    `"use strict";\n${patchSource}\nreturn patchArchivedSettingsOfflineVisibility;`,
+  )("/*codex-offline:archived-settings-offline-local-visibility*/");
+  const fixture =
+    "let H=V,U=D&&!k,pe=N&&ee&&!ne," +
+    "_e=H.length===0&&(c&&w||T==null&&M||N&&L==null&&ae),G;" +
+    "return jsx(dn,{archivedChats:H,projects:B,isError:_e,onLoadNextPage:G});";
+
+  const result = patchArchivedSettingsOfflineVisibility(fixture);
+  assert.equal(result.patched, true);
+  assert.match(result.content, /_e=H\.length===0&&c&&w,G/);
+  assert.match(
+    result.content,
+    /isError:_e\/\*codex-offline:archived-settings-offline-local-visibility\*\/,onLoadNextPage:G/,
+  );
+  assert.ok(!result.content.includes("T==null&&M"));
+  assert.ok(!result.content.includes("N&&L==null&&ae"));
 });
 
 test("26.727 Workspace Dependencies enables the current adjacent gate layout", () => {
@@ -472,6 +629,43 @@ test("26.727 verifier recognizes the current agent settings surface", () => {
     true,
   );
   assert.equal(hasWorkspaceDependenciesSettingsSurface("other surface"), false);
+});
+
+test("26.810 dynamic tool bridge accepts ownership guards before execution claim", () => {
+  const regexSource = sourceSlice(
+    "  const COMPUTER_USE_NODE_REPL_DYNAMIC_TOOL_CALL_CURRENT_V4_RE =",
+    "\n  const COMPUTER_USE_NODE_REPL_RESULT_TEXT_CODE =",
+  );
+  const currentRegex = Function(
+    `"use strict";\n${regexSource}\nreturn COMPUTER_USE_NODE_REPL_DYNAMIC_TOOL_CALL_CURRENT_V4_RE;`,
+  )();
+  const fixture =
+    "async function Hfu({scope:e,serverRequest:t,hostId:n,queryClient:r}){" +
+    "let{id:i,params:a}=t,{threadId:o,tool:s}=a;if(!o){" +
+    "Bf.error(`Missing threadId for dynamic tool call request`,{safe:{},sensitive:{id:i,params:a}});return}" +
+    "let c=Ql(o),l=new K9r(e).getForHostId(n),u=l?.getConversation(c)," +
+    "d=Hv(u,a.turnId),f=d?.items.find(e=>e.type===`userMessage`);" +
+    "if(f?.clientId!=null&&f.clientId!==d?.params.clientUserMessageId)return;" +
+    "if(f?.clientId==null&&f?.content?.some(e=>e.type===`text`&&e.text.startsWith(`<realtime_delegation>`))){" +
+    "let t=e.get(HE);if(t.locator?.hostId!==n||t.locator.conversationId!==c)return}" +
+    "if(l?.getStreamRole?.(c)==null&&n===`local`&&_m.clientCoordination!=null)try{" +
+    "if(await _m.clientCoordination.findThreadOwner({hostId:n,conversationId:c})!=null)return}" +
+    "catch(e){qp.warning(`dynamic_tool_call_owner_discovery_failed`,{safe:{threadId:o,hostId:n},sensitive:{error:e}})}" +
+    "if(_m.dynamicToolCalls!=null&&!await _m.dynamicToolCalls.tryClaimExecution(" +
+    "{callId:a.callId,hostId:n,threadId:o,turnId:a.turnId}))return;" +
+    "let p,m=a.namespace===Rzl,h=a.namespace==null&&KBl.has(s)," +
+    "g=m||h?await dHc({argumentsValue:a.arguments}):null," +
+    "_=a.namespace===`plugin_management`||a.namespace===`openai_settings`?await XLc(a,{hostId:n}):null;" +
+    "if(_!=null)p=_;else if(!m&&!h)p=fC(`Unsupported dynamic tool namespace: ${a.namespace}`);" +
+    "else if(g!=null)p=g;else";
+  const match = currentRegex.exec(fixture);
+
+  assert.ok(match);
+  assert.equal(match.groups.hostId, "n");
+  assert.equal(match.groups.params, "a");
+  assert.equal(match.groups.result, "p");
+  assert.equal(match.groups.failureFn, "fC");
+  assert.ok(match.groups.prefix.includes("dynamic_tool_call_owner_discovery_failed"));
 });
 
 test("26.730 node_repl config keeps env_vars when adding the sandbox bypass", () => {
@@ -572,6 +766,14 @@ test("26.803 packaging shortens the Sky tslib dependency cache path", () => {
       "'_internal\\app\\resources\\cua_node\\bin\\node_modules\\@oai\\sky\\dist\\js-deps\\tslib.es6.js'",
     ),
   );
+});
+
+test("26.810 packaging shortens the Sky pnpm tslib dependency path", () => {
+  assert.ok(buildScriptSource.includes("'node_modules/.pnpm'"));
+  assert.ok(
+    buildScriptSource.includes("(?:js-dependency-cache|node_modules/\\.pnpm)"),
+  );
+  assert.ok(verifierScriptSource.includes("'node_modules\\.pnpm'"));
 });
 
 test("26.730 patcher does not carry pre-helper node_repl migrations", () => {

--- a/scripts/test/offline-ui-gates.test.cjs
+++ b/scripts/test/offline-ui-gates.test.cjs
@@ -52,8 +52,10 @@ const requiredOfflineUiGates = {
   "2177625257": "browser history and profile import",
   "4039078146": "sidebar activity view",
   "717035860": "sidebar customization and destination discovery",
+  "3278809559": "current import settings page",
+  "1042620455": "remote connections",
+  "4114442250": "remote connections feature flag",
 };
-const cloudOnlyGateIds = ["1042620455", "4114442250"];
 
 test("offline builds force the supported product and navigation UI gates", () => {
   for (const [gateId, label] of Object.entries(requiredOfflineUiGates)) {
@@ -103,16 +105,9 @@ test("offline builds select the unified plugins page instead of the legacy store
   );
 });
 
-test("offline builds do not force cloud-only remote connection gates", () => {
-  for (const gateId of cloudOnlyGateIds) {
-    assert.equal(contract.STATSIG_DEFAULT_FEATURE_OVERRIDES[gateId], undefined, gateId);
-    assert.equal(contract.DESKTOP_ASAR_KNOWN_GATE_IDS.includes(gateId), false, gateId);
-    assert.doesNotMatch(
-      initSource,
-      new RegExp(`["']${gateId}["']\\s*:\\s*true`),
-      `${gateId}: desktop runtime must preserve the official cloud gate`,
-    );
-  }
+test("package verification tracks the current import settings gate chunk", () => {
+  assert.match(verifyScriptSource, /import-settings-gate-/);
+  assert.match(verifyScriptSource, /currentImportSettingsGateIds/);
 });
 
 test("runtime gate fallback patches custom sessions and asynchronous IPC results", () => {

--- a/scripts/test/offline-ui-gates.test.cjs
+++ b/scripts/test/offline-ui-gates.test.cjs
@@ -110,6 +110,29 @@ test("package verification tracks the current import settings gate chunk", () =>
   assert.match(verifyScriptSource, /currentImportSettingsGateIds/);
 });
 
+test("package verification fails closed when the current import settings gate chunk is missing", () => {
+  const importSettingsBlockStart = verifyScriptSource.indexOf(
+    "const importSettingsGateEntries = entries.filter(entry =>",
+  );
+  const importSettingsBlockEnd = verifyScriptSource.indexOf(
+    "\n\nif (!entryMap.has('package.json')) {",
+    importSettingsBlockStart,
+  );
+  assert.notEqual(importSettingsBlockStart, -1, "import settings gate verification block is missing");
+  assert.notEqual(importSettingsBlockEnd, -1, "import settings gate verification block terminator is missing");
+
+  const importSettingsBlock = verifyScriptSource.slice(
+    importSettingsBlockStart,
+    importSettingsBlockEnd,
+  );
+  assert.match(importSettingsBlock, /importSettingsGateEntries\.length/);
+  assert.match(
+    importSettingsBlock,
+    /importSettingsGateEntries\.length\s*===\s*0[\s\S]*throw new Error\(/,
+    "missing import settings gate chunk must stop package verification",
+  );
+});
+
 test("runtime gate fallback patches custom sessions and asynchronous IPC results", () => {
   assert.match(
     initSource,
@@ -387,6 +410,20 @@ test("priority surface carries its dedicated static gate marker", () => {
   const currentResult = patchSidebarActivitySurface(currentFixture);
   assert.equal(currentResult.patched, true);
   assert.equal(currentResult.sidebarCorrect, true);
+
+  const latestFixture =
+    "function FUc(){let e=qh(LUc),t=J(Tv);return e&&(t.status===`allowed`||t.status===`loading`)}" +
+    "LUc=`4039078146`";
+  const latestResult = patchSidebarActivitySurface(latestFixture);
+  assert.equal(latestResult.patched, true);
+  assert.equal(latestResult.sidebarSurfaceSeen, true);
+  assert.equal(latestResult.sidebarCorrect, true);
+  assert.ok(latestResult.content.includes(`e=!0${sidebarMarker},t=J(Tv)`));
+
+  const latestSecondPass = patchSidebarActivitySurface(latestResult.content);
+  assert.equal(latestSecondPass.patched, false);
+  assert.equal(latestSecondPass.sidebarCorrect, true);
+
   assert.ok(contract.DESKTOP_ASAR_PATCH_MARKERS.includes(sidebarMarker), sidebarMarker);
   assert.ok(verifyScriptSource.includes(`requiredPatchMarker('${sidebarMarker}')`));
 });

--- a/scripts/verify-offline-package.ps1
+++ b/scripts/verify-offline-package.ps1
@@ -442,6 +442,11 @@ try {
         if ($initPatchContent -notmatch "'3413548395'\s*:\s*false") {
             throw "Packaged init.cjs does not select the unified plugins page: $relativePath"
         }
+        foreach ($gateId in @('3278809559', '1042620455', '4114442250')) {
+            if ($initPatchContent -notmatch "'$gateId'\s*:\s*true") {
+                throw "Packaged init.cjs does not enable settings gate '$gateId': $relativePath"
+            }
+        }
     }
 
     foreach ($relativePath in @('_internal\patches\plugin-service-compat.cjs', '_internal\app\patches\plugin-service-compat.cjs')) {
@@ -1281,6 +1286,8 @@ const DESKTOP_ASAR_PATCH_MARKERS = capabilityContract.DESKTOP_ASAR_PATCH_MARKERS
 const DESKTOP_ASAR_KNOWN_GATE_IDS = capabilityContract.DESKTOP_ASAR_KNOWN_GATE_IDS || [];
 const DESKTOP_BROWSER_USE_AVAILABILITY_MARKERS = capabilityContract.DESKTOP_BROWSER_USE_AVAILABILITY_MARKERS || [];
 const DESKTOP_BROWSER_USE_CAPABILITY_KEYS = capabilityContract.DESKTOP_BROWSER_USE_CAPABILITY_KEYS || [];
+const REQUIRED_STATSIG_FEATURE_MARKERS = capabilityContract.REQUIRED_STATSIG_FEATURE_MARKERS || [];
+const STATSIG_DEFAULT_FEATURE_OVERRIDES = capabilityContract.STATSIG_DEFAULT_FEATURE_OVERRIDES || {};
 function requiredPatchMarker(marker) {
   if (!DESKTOP_ASAR_PATCH_MARKERS.includes(marker)) {
     throw new Error(`Capability contract is missing required app.asar patch marker: ${marker}`);
@@ -1469,6 +1476,31 @@ const entryMap = new Map(
   rawEntries.map(entry => [normalize(entry), entry.replace(/^[\\/]+/, '')])
 );
 const entries = Array.from(entryMap.keys());
+
+const importSettingsGateEntries = entries.filter(entry =>
+  /(^|\/)webview\/assets\/import-settings-gate-[^/]+\.js$/.test(entry)
+);
+const currentImportSettingsGateIds = new Set();
+for (const entry of importSettingsGateEntries) {
+  const content = asar.extractFile(asarPath, entryMap.get(entry)).toString('utf8');
+  for (const match of content.matchAll(/`(\d+)`/g)) {
+    currentImportSettingsGateIds.add(match[1]);
+  }
+}
+if (importSettingsGateEntries.length > 0 && currentImportSettingsGateIds.size === 0) {
+  throw new Error('Import settings gate chunk exists but its gate id could not be resolved.');
+}
+for (const gateId of currentImportSettingsGateIds) {
+  if (STATSIG_DEFAULT_FEATURE_OVERRIDES[gateId] !== true) {
+    throw new Error(`Current import settings gate is not enabled by the capability contract: ${gateId}`);
+  }
+  if (!DESKTOP_ASAR_KNOWN_GATE_IDS.includes(gateId)) {
+    throw new Error(`Current import settings gate is missing from the ASAR gate list: ${gateId}`);
+  }
+  if (!REQUIRED_STATSIG_FEATURE_MARKERS.includes(gateId)) {
+    throw new Error(`Current import settings gate is not required during package verification: ${gateId}`);
+  }
+}
 
 if (!entryMap.has('package.json')) {
   throw new Error('package.json was not found inside app.asar.');

--- a/scripts/verify-offline-package.ps1
+++ b/scripts/verify-offline-package.ps1
@@ -1071,8 +1071,10 @@ try {
             if (-not (Test-Path $computerUseShortTslibPath -PathType Leaf)) {
                 throw 'Bundled computer-use runtime is missing its MAX_PATH-safe tslib dependency.'
             }
-            if (Test-Path (Join-Path $computerUseSkyDistRoot 'js-dependency-cache') -PathType Container) {
-                throw 'Bundled computer-use runtime still contains the long Sky dependency cache path.'
+            foreach ($longCacheRelativePath in @('js-dependency-cache', 'node_modules\.pnpm')) {
+                if (Test-Path (Join-Path $computerUseSkyDistRoot $longCacheRelativePath) -PathType Container) {
+                    throw "Bundled computer-use runtime still contains the long Sky dependency cache path: $longCacheRelativePath"
+                }
             }
             $computerUseSkyJavaScript = @(
                 Get-ChildItem -LiteralPath $computerUseSkyDistRoot -Recurse -Filter '*.js' -File
@@ -1084,7 +1086,7 @@ try {
                 throw 'Bundled computer-use runtime does not import its MAX_PATH-safe tslib dependency.'
             }
             $longTslibImports = @(
-                $computerUseSkyJavaScript | Select-String -SimpleMatch 'js-dependency-cache'
+                $computerUseSkyJavaScript | Select-String -Pattern 'js-dependency-cache|node_modules/\.pnpm'
             )
             if ($longTslibImports.Count -gt 0) {
                 throw 'Bundled computer-use runtime still imports the long Sky dependency cache path.'
@@ -1394,11 +1396,11 @@ const LEGACY_PLUGIN_RENDERER_PATCH_MARKERS = [
 ];
 const sidebarActivityPatchedSurfaceRe = new RegExp(
   `([A-Za-z_$][\\w$]*)=!0${escapeRegExp(SIDEBAR_ACTIVITY_VIEW_PATCH_MARKER)},` +
-    `([A-Za-z_$][\\w$]*)=q\\([A-Za-z_$][\\w$]*\\);return \\1&&` +
+    `([A-Za-z_$][\\w$]*)=[A-Za-z_$][\\w$]*\\([A-Za-z_$][\\w$]*\\);return \\1&&` +
     '\\(\\2\\.status===`allowed`\\|\\|\\2\\.status===`loading`\\)'
 );
 const sidebarActivityUnpatchedSurfaceRe =
-  /([A-Za-z_$][\w$]*)=([A-Za-z_$][\w$]*)\(([A-Za-z_$][\w$]*)\),([A-Za-z_$][\w$]*)=q\([A-Za-z_$][\w$]*\);return \1&&\(\4\.status===`allowed`\|\|\4\.status===`loading`\)\}[^]*?\3=`4039078146`/;
+  /([A-Za-z_$][\w$]*)=([A-Za-z_$][\w$]*)\(([A-Za-z_$][\w$]*)\),([A-Za-z_$][\w$]*)=[A-Za-z_$][\w$]*\([A-Za-z_$][\w$]*\);return \1&&\(\4\.status===`allowed`\|\|\4\.status===`loading`\)\}[^]*?\3=`4039078146`/;
 const legacyPluginsPageSelectionRe = new RegExp(
   `([A-Za-z_$][\\w$]*)=!0${escapeRegExp(RENDERER_KNOWN_STATSIG_GATES_PATCH_MARKER)}` +
     '&&([A-Za-z_$][\\w$]*)===`plugins`&&\\(' +
@@ -1480,6 +1482,9 @@ const entries = Array.from(entryMap.keys());
 const importSettingsGateEntries = entries.filter(entry =>
   /(^|\/)webview\/assets\/import-settings-gate-[^/]+\.js$/.test(entry)
 );
+if (importSettingsGateEntries.length === 0) {
+  throw new Error('Current import settings gate chunk was not found in app.asar.');
+}
 const currentImportSettingsGateIds = new Set();
 for (const entry of importSettingsGateEntries) {
   const content = asar.extractFile(asarPath, entryMap.get(entry)).toString('utf8');
@@ -1487,7 +1492,7 @@ for (const entry of importSettingsGateEntries) {
     currentImportSettingsGateIds.add(match[1]);
   }
 }
-if (importSettingsGateEntries.length > 0 && currentImportSettingsGateIds.size === 0) {
+if (currentImportSettingsGateIds.size === 0) {
   throw new Error('Import settings gate chunk exists but its gate id could not be resolved.');
 }
 for (const gateId of currentImportSettingsGateIds) {

--- a/web-gateway/gateway/src/ipc/codex/capabilityContractData.cjs
+++ b/web-gateway/gateway/src/ipc/codex/capabilityContractData.cjs
@@ -33,6 +33,7 @@ const STATSIG_DEFAULT_FEATURE_OVERRIDES = Object.freeze({
   "2900529421": true,
   "2711149772": true,
   "816842483": true,
+  "3278809559": true,
   artifacts: true,
   // From DESKTOP_ASAR_KNOWN_GATE_IDS (previously only bypassed in ASAR)
   "3075919032": true,
@@ -58,6 +59,8 @@ const STATSIG_DEFAULT_FEATURE_OVERRIDES = Object.freeze({
   "4100906017": true,
   "1444479692": true,
   "717035860": true,
+  "1042620455": true,
+  "4114442250": true,
 });
 
 const DEFAULT_DESKTOP_FEATURE_STATE = Object.freeze({
@@ -125,6 +128,9 @@ const REQUIRED_STATSIG_FEATURE_MARKERS = Object.freeze([
   "3903742690",
   "3326157269",
   "2900529421",
+  "3278809559",
+  "1042620455",
+  "4114442250",
 ]);
 
 const REQUIRED_DESKTOP_FEATURE_MARKERS = Object.freeze([
@@ -193,11 +199,14 @@ const DESKTOP_ASAR_KNOWN_GATE_IDS = Object.freeze([
   "2900529421",
   "2711149772",
   "816842483",
+  "3278809559",
   "1244621283",
   "4100906017",
   "2574306096",
   "1444479692",
   "717035860",
+  "1042620455",
+  "4114442250",
   "839469903",
 ]);
 

--- a/web-gateway/gateway/test/capabilityContract.test.cjs
+++ b/web-gateway/gateway/test/capabilityContract.test.cjs
@@ -20,6 +20,9 @@ test("capability contract exports required statsig defaults", () => {
     "3903742690",
     "3326157269",
     "2900529421",
+    "3278809559",
+    "1042620455",
+    "4114442250",
   ]) {
     assert.equal(contract.STATSIG_DEFAULT_FEATURE_OVERRIDES[key], true, key);
   }
@@ -160,6 +163,9 @@ test("source data contract covers direct exe asar patch surfaces", () => {
     "2900529421",
     "2711149772",
     "816842483",
+    "3278809559",
+    "1042620455",
+    "4114442250",
   ]) {
     assert.ok(contractData.DESKTOP_ASAR_KNOWN_GATE_IDS.includes(gateId), gateId);
   }
@@ -205,10 +211,11 @@ test("source data contract covers direct exe asar patch surfaces", () => {
   );
 });
 
-test("offline contract does not force cloud-only remote connection gates", () => {
-  for (const gateId of ["1042620455", "4114442250"]) {
-    assert.equal(contractData.STATSIG_DEFAULT_FEATURE_OVERRIDES[gateId], undefined, gateId);
-    assert.equal(contractData.DESKTOP_ASAR_KNOWN_GATE_IDS.includes(gateId), false, gateId);
+test("offline contract keeps import and remote connection settings available", () => {
+  for (const gateId of ["3278809559", "1042620455", "4114442250"]) {
+    assert.equal(contractData.STATSIG_DEFAULT_FEATURE_OVERRIDES[gateId], true, gateId);
+    assert.ok(contractData.DESKTOP_ASAR_KNOWN_GATE_IDS.includes(gateId), gateId);
+    assert.ok(contractData.REQUIRED_STATSIG_FEATURE_MARKERS.includes(gateId), gateId);
   }
 });
 


### PR DESCRIPTION
## Summary

- restore the latest offline Import and Connections settings through the shared capability contract
- adapt the version-locked 26.810 desktop patches for dynamic tools, archived settings, Sidebar Activity, Sky dependency caches, and the Chrome browser client
- fail closed when staged cache paths contain NTFS reparse points or the current import-settings gate cannot be discovered
- synchronize the compatibility inventory and release notes

## Test coverage

- 11/11 changed behavior points covered (100%)
- `node --test .\scripts\test\*.test.cjs .\web-gateway\gateway\test\*.test.cjs`: 115/115 passed
- `npm --prefix .\web-gateway run build:gateway`: passed
- PowerShell parser checks, Node syntax checks, and `git diff --check`: passed
- full `26.810.7004.0` installer build with `-RequireInstaller`: passed
- offline package verifier: passed
- direct executable launch: app-server ready, window ready, survived the 30-second offline observation window
- local setup SHA256: `c4d150188110d4984fd10c045760ef4351fb02e43fdcfe039f260094c59fb2d2`

## Pre-landing review

- two P1 findings were identified and fixed:
  - recursive staging cleanup could follow an NTFS junction/reparse point
  - import-settings gate discovery could pass when its current chunk was absent
- remaining P0/P1 findings: 0
- no new dependencies; scope is limited to the compatibility boundary, its verifier/tests, and release documentation

## Release behavior

Merging to `main` triggers the repository release workflow, which resolves the current Store version, rebuilds the package, creates `offline-v<version>`, and uploads the release assets. No tag or release is pre-created by this PR.

## Known verification gap

The final installer's full manual click matrix for Archived, Activity, Import, and Connections was not repeated on this exact candidate because the available desktop automation policy prohibits controlling the Codex UI. Version-locked bundle fixtures, final-ASAR verification, package integrity checks, direct launch, and earlier isolated Import/Connections UI clicks cover the affected paths.

## Documentation

- `CHANGELOG.md`: the 26.810 release entry covers the build failure, compatibility patches, fail-closed safety guards, and 115-test verification matrix.
- `docs/plan-b-patch-migration-inventory.md`: records the 26.810 renderer/Sky/browser compatibility boundaries and updates the verified gate-contract count to 44.
- `docs/issue-59-gateway-vs-patch-analysis.md`: updates the historical architecture analysis to the current 44-gate shared contract.
- `README.md`, `AGENTS.md`, and the remaining maintenance documents were audited and remain current; all `docs/*.md` files are discoverable from an entry-point document.
