### PR TITLE
修复 primary runtime 解压失败（issue #108）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 2026-09-04
+
+### 中文
+
+- 修复本地构建在解压 primary runtime 插件包（`.tar.xz`）时报 `tar exit code 1` 的问题：构建现在优先使用 Windows 自带的 `System32\tar.exe`，并先用 `--version` 确认它支持 xz（bsdtar 需带 `liblzma`，GNU tar 需有 `xz` 且以 `--force-local` 调用）；都不满足时回退到 7-Zip，没有可用解压器时失败关闭并列出检查过的候选。解压失败还会带上解压器的真实输出与排查提示（缺少 xz 支持、符号链接权限、杀软占用、磁盘不足、工作目录过深或含非 ASCII 字符）。
+
+### English
+
+- Fixed local builds failing with `tar exit code 1` while extracting the primary runtime plugin archive (`.tar.xz`). The build now prefers the Windows-bundled `System32\tar.exe`, probes `--version` to confirm xz support (bsdtar must report `liblzma`; GNU tar needs an `xz` binary and is invoked with `--force-local`), falls back to 7-Zip when no tar qualifies, and fails closed listing every inspected candidate when nothing can read the archive. Extraction failures now carry the extractor's real output plus hints for the known causes: missing xz support, symlink privilege, antivirus locks, a full disk, and deep or non-ASCII work roots.
+
 ## 2026-09-03
 
 ### 中文

--- a/README.md
+++ b/README.md
@@ -123,6 +123,12 @@ pwsh -NoProfile -File ./scripts/build-offline-package.ps1
 
 产物输出到 `dist/offline/<release-name>/`。
 
+构建需要一个能解压 `.tar.xz` 的工具来展开 primary runtime 插件包：`tar --version`
+里带 `liblzma` 的 `tar.exe`（Windows 自带的 `%SystemRoot%\System32\tar.exe` 在部分
+版本上只链接了 zlib），或者安装 7-Zip 作为回退。两者都没有时构建会直接失败并列出
+检查过的路径。仓库路径过深或含非 ASCII 字符时，用 `-WorkRoot C:\codex-build` 指定
+一个短的纯 ASCII 工作目录。
+
 ### 核心脚本
 
 | 脚本 | 用途 |
@@ -157,6 +163,7 @@ pwsh -NoProfile -File ./scripts/build-offline-package.ps1
 - [插件服务兼容迁移计划](docs/plugin-service-compat-migration-plan.md)
 - [插件服务兼容实施记录](docs/implementation-notes-plugin-service-compat.md)
 - [API/custom provider 模型目录](docs/models-api.md)
+- [Primary runtime 解压失败排查](docs/issue-108-primary-runtime-extract-failure.md)
 
 ## 配置
 
@@ -219,6 +226,8 @@ bash setup-linux.sh update
 ### Building from Source
 
 Windows 10/11 x64, Node.js 18+, PowerShell 7+, optional Inno Setup 6.
+
+Extracting the primary runtime plugin archive needs a `.tar.xz` reader: a `tar.exe` whose `tar --version` reports `liblzma` (some Windows builds ship `%SystemRoot%\System32\tar.exe` linked against zlib only), or 7-Zip as a fallback. Pass `-WorkRoot C:\codex-build` when the checkout path is deep or contains non-ASCII characters.
 
 ```powershell
 npm ci

--- a/docs/issue-108-primary-runtime-extract-failure.md
+++ b/docs/issue-108-primary-runtime-extract-failure.md
@@ -61,13 +61,23 @@ installer, or the packaged output changes.
 The post-extraction `marketplace.json` check is unchanged, so a partial
 extraction still fails the build.
 
+`scripts/test/current-bundle-compatibility.test.cjs` ran the build script's
+whole helper block through `powershell.exe -Command`. That payload was already
+near the 32,767-character Windows command-line limit and the new helpers pushed
+it past it, so `spawnSync` failed to launch and the test reported only
+`null !== 0`. It now writes the block to a temporary `.ps1` and runs it with
+`-File`, and reports `result.error` when the process never starts.
+
 ## Verification
 
 - `node --test scripts/test/primary-runtime-archive-extraction.test.cjs` — 6
   tests, all failing against the previous implementation.
-- `node --test scripts/test/*.test.cjs` — the two `repair-threads` PowerShell
-  cases fail only because no `pwsh` is installed in the sandbox used for this
-  change; they are unrelated to the extraction path.
+- `node --test scripts/test/*.test.cjs` — the three PowerShell cases that spawn
+  `powershell.exe` are skipped or fail only because the sandbox used for this
+  change has no Windows PowerShell; they are unrelated to the extraction path.
+- The Windows-only `rg_adguard app-source cache` case was re-run against
+  PowerShell 7.4 with the file-based invocation and passes (53/53 in that
+  file).
 - PowerShell AST parse of `scripts/build-offline-package.ps1` reports no
   syntax errors (the same check CI runs).
 - Behavior was exercised on PowerShell 7.4 with stub extractors: a bsdtar

--- a/docs/issue-108-primary-runtime-extract-failure.md
+++ b/docs/issue-108-primary-runtime-extract-failure.md
@@ -1,0 +1,85 @@
+# Issue 108: Primary runtime archive extraction failure
+
+## Symptom
+
+```
+Failed to extract Codex primary runtime archive with tar exit code 1
+```
+
+The build reached `Resolve-OfflineRuntimePluginMarketplaceRoot`, downloaded
+`codex-primary-runtime-win32-x64-<version>.tar.xz`, and failed while
+extracting it. The archive itself is never the problem at that point: the
+SHA256 is verified before extraction, so a truncated or substituted download
+fails earlier with a hash mismatch.
+
+## Root cause
+
+The build shelled out to whatever `tar` `Get-Command` returned and reported
+only `$LASTEXITCODE`. Both halves of that are wrong on a developer machine:
+
+1. **The extractor was never checked for xz support.** Windows bundles bsdtar
+   as `%SystemRoot%\System32\tar.exe`, and several Windows builds ship it
+   linked against zlib only (`tar --version` lists no `liblzma`). Such a
+   `tar.exe` cannot open a `.tar.xz` at all and exits 1 with
+   `Unrecognized archive format`. The GitHub `windows-latest` runner ships a
+   newer build that does include `liblzma`, which is why CI stayed green while
+   local builds failed.
+2. **`Get-Command tar` can resolve to an MSYS/Cygwin GNU tar** (Git for
+   Windows, MSYS2) when it precedes `System32` on `PATH`. GNU tar reads the
+   drive letter in `C:\...` as a remote host specification and also needs a
+   separate `xz` binary for `.tar.xz`.
+3. **tar's own diagnostics were discarded.** `& $tarCommand.Source -xf ...`
+   left stderr to the console and the thrown error carried only the exit code,
+   so the reported failure could not be told apart from the other Windows
+   extraction failures that also exit 1: symlink creation without developer
+   mode or elevation, antivirus locking files, a full disk, or a work root
+   deep or non-ASCII enough to break path resolution.
+
+## Fix boundary
+
+All changes are in `scripts/build-offline-package.ps1`, inside the primary
+runtime plugin step. Nothing about the Gateway, the desktop patches, the
+installer, or the packaged output changes.
+
+- `Resolve-ArchiveExtractionTool` inspects `%SystemRoot%\System32\tar.exe`
+  before any `tar` on `PATH`, probes each candidate with `--version`, and
+  accepts a bsdtar only when it reports `liblzma`, a GNU tar only when an `xz`
+  binary is available (invoked with `--force-local` so the drive letter stays
+  local).
+- When no tar can read xz, the build falls back to 7-Zip (`7z`/`7zz`/`7za` on
+  `PATH`, or the standard `7-Zip\7z.exe` install locations), decompressing
+  `.tar.xz` to a staged `.tar` and then unpacking that. The staging directory
+  is always removed.
+- With no usable extractor at all the build fails closed and names every
+  candidate it inspected.
+- `Invoke-CapturedProcess` captures stdout and stderr, and
+  `New-ArchiveExtractionErrorMessage` puts the last 20 output lines into the
+  thrown error together with hints matched from that output (no xz support,
+  symlink privilege, permission denied or file in use, out of disk) and from
+  the extraction root itself (longer than 120 characters, or non-ASCII).
+
+The post-extraction `marketplace.json` check is unchanged, so a partial
+extraction still fails the build.
+
+## Verification
+
+- `node --test scripts/test/primary-runtime-archive-extraction.test.cjs` — 6
+  tests, all failing against the previous implementation.
+- `node --test scripts/test/*.test.cjs` — the two `repair-threads` PowerShell
+  cases fail only because no `pwsh` is installed in the sandbox used for this
+  change; they are unrelated to the extraction path.
+- PowerShell AST parse of `scripts/build-offline-package.ps1` reports no
+  syntax errors (the same check CI runs).
+- Behavior was exercised on PowerShell 7.4 with stub extractors: a bsdtar
+  without `liblzma` plus 7-Zip selects 7-Zip, extracts through the staged tar
+  and removes the stage; a bsdtar with `liblzma` is used directly and its
+  failure output reaches the thrown message with the matching hint; GNU tar
+  gets `--force-local`; with no extractor present the fail-closed message
+  lists what was inspected.
+
+## Residual risk
+
+The 7-Zip fallback is not exercised by CI, which always resolves a capable
+`tar.exe`. Extraction root length and character-set problems are reported as
+hints, not fixed automatically — a deep or non-ASCII checkout still needs
+`-WorkRoot` pointed at a short ASCII path.

--- a/scripts/build-offline-package.ps1
+++ b/scripts/build-offline-package.ps1
@@ -442,6 +442,283 @@ function Get-ChromeExtensionConfig {
     }
 }
 
+function Invoke-CapturedProcess {
+    param(
+        [Parameter(Mandatory = $true)][string]$FilePath,
+        [Parameter(Mandatory = $true)][string[]]$Arguments
+    )
+
+    $stdoutPath = [System.IO.Path]::GetTempFileName()
+    $stderrPath = [System.IO.Path]::GetTempFileName()
+    try {
+        $quotedArguments = @($Arguments | ForEach-Object {
+            if ($_ -match '\s') { '"' + $_ + '"' } else { $_ }
+        })
+
+        $process = Start-Process -FilePath $FilePath -ArgumentList $quotedArguments -NoNewWindow -Wait -PassThru -RedirectStandardOutput $stdoutPath -RedirectStandardError $stderrPath
+        $outputParts = @()
+        foreach ($capturePath in @($stdoutPath, $stderrPath)) {
+            $captured = Get-Content -LiteralPath $capturePath -Raw -ErrorAction SilentlyContinue
+            if (-not [string]::IsNullOrWhiteSpace($captured)) {
+                $outputParts += $captured.TrimEnd()
+            }
+        }
+
+        return [ordered]@{
+            exitCode = [int]$process.ExitCode
+            output = ($outputParts -join [System.Environment]::NewLine)
+        }
+    }
+    finally {
+        Remove-Item -LiteralPath $stdoutPath -Force -ErrorAction SilentlyContinue
+        Remove-Item -LiteralPath $stderrPath -Force -ErrorAction SilentlyContinue
+    }
+}
+
+function Get-ArchiveToolCapability {
+    param([Parameter(Mandatory = $true)][string]$ToolPath)
+
+    $versionText = ''
+    try {
+        $probe = Invoke-CapturedProcess -FilePath $ToolPath -Arguments @('--version')
+        $versionText = [string]$probe.output
+    }
+    catch {
+        $versionText = ''
+    }
+
+    if ($versionText -match '(?i)bsdtar|libarchive') {
+        # Windows ships bsdtar without liblzma on several builds, so those tar.exe copies
+        # cannot read the .tar.xz primary runtime archive at all.
+        return [ordered]@{
+            flavor = 'bsdtar'
+            supportsXz = ($versionText -match '(?i)liblzma')
+            version = $versionText
+        }
+    }
+
+    if ($versionText -match '(?i)GNU tar') {
+        # GNU tar shells out to the xz binary for .tar.xz payloads.
+        $xzCommand = Get-Command 'xz' -CommandType Application -ErrorAction SilentlyContinue | Select-Object -First 1
+        return [ordered]@{
+            flavor = 'gnutar'
+            supportsXz = ($null -ne $xzCommand)
+            version = $versionText
+        }
+    }
+
+    return [ordered]@{
+        flavor = 'unknown'
+        supportsXz = $false
+        version = $versionText
+    }
+}
+
+function Get-SevenZipCandidatePath {
+    $candidates = New-Object System.Collections.Generic.List[string]
+    foreach ($commandName in @('7z', '7zz', '7za')) {
+        $command = Get-Command $commandName -CommandType Application -ErrorAction SilentlyContinue | Select-Object -First 1
+        if ($null -ne $command) {
+            $candidates.Add([string]$command.Source)
+        }
+    }
+
+    foreach ($programFilesRoot in @($env:ProgramFiles, ${env:ProgramFiles(x86)})) {
+        if ([string]::IsNullOrWhiteSpace($programFilesRoot)) { continue }
+        $candidates.Add((Join-Path $programFilesRoot '7-Zip\7z.exe'))
+    }
+
+    return $candidates.ToArray()
+}
+
+function Resolve-ArchiveExtractionTool {
+    $inspected = New-Object System.Collections.Generic.List[string]
+    $seenPaths = New-Object System.Collections.Generic.List[string]
+    $tarCandidates = New-Object System.Collections.Generic.List[string]
+
+    if (-not [string]::IsNullOrWhiteSpace($env:SystemRoot)) {
+        # Prefer the Windows-bundled bsdtar: a Git/MSYS GNU tar earlier on PATH reads
+        # "C:\..." as a remote host specification and cannot extract into a Windows path.
+        $tarCandidates.Add((Join-Path $env:SystemRoot 'System32\tar.exe'))
+    }
+
+    $pathTar = Get-Command 'tar' -CommandType Application -ErrorAction SilentlyContinue | Select-Object -First 1
+    if ($null -ne $pathTar) {
+        $tarCandidates.Add([string]$pathTar.Source)
+    }
+
+    $fallbackTarPath = ''
+    foreach ($candidate in $tarCandidates) {
+        if ([string]::IsNullOrWhiteSpace($candidate)) { continue }
+        if ($seenPaths -contains $candidate.ToLowerInvariant()) { continue }
+        $seenPaths.Add($candidate.ToLowerInvariant())
+        if (-not (Test-Path -LiteralPath $candidate -PathType Leaf)) { continue }
+
+        $capability = Get-ArchiveToolCapability -ToolPath $candidate
+        $inspected.Add("$candidate [$($capability.flavor), xz=$($capability.supportsXz)]")
+        if ($capability.supportsXz) {
+            return [ordered]@{
+                kind = 'tar'
+                path = $candidate
+                forceLocal = ($capability.flavor -eq 'gnutar')
+                inspected = $inspected.ToArray()
+            }
+        }
+
+        if ([string]::IsNullOrWhiteSpace($fallbackTarPath) -and $capability.flavor -eq 'unknown') {
+            $fallbackTarPath = $candidate
+        }
+    }
+
+    foreach ($sevenZipCandidate in (Get-SevenZipCandidatePath)) {
+        if ([string]::IsNullOrWhiteSpace($sevenZipCandidate)) { continue }
+        if ($seenPaths -contains $sevenZipCandidate.ToLowerInvariant()) { continue }
+        $seenPaths.Add($sevenZipCandidate.ToLowerInvariant())
+        if (-not (Test-Path -LiteralPath $sevenZipCandidate -PathType Leaf)) { continue }
+
+        $inspected.Add("$sevenZipCandidate [7-zip]")
+        return [ordered]@{
+            kind = 'sevenzip'
+            path = $sevenZipCandidate
+            forceLocal = $false
+            inspected = $inspected.ToArray()
+        }
+    }
+
+    if (-not [string]::IsNullOrWhiteSpace($fallbackTarPath)) {
+        return [ordered]@{
+            kind = 'tar'
+            path = $fallbackTarPath
+            forceLocal = $false
+            inspected = $inspected.ToArray()
+        }
+    }
+
+    return [ordered]@{
+        kind = 'none'
+        path = ''
+        forceLocal = $false
+        inspected = $inspected.ToArray()
+    }
+}
+
+function Get-ArchiveExtractionHint {
+    param(
+        [Parameter(Mandatory = $true)][AllowEmptyString()][string]$Output,
+        [Parameter(Mandatory = $true)][string]$ExtractRoot
+    )
+
+    $hints = New-Object System.Collections.Generic.List[string]
+    if ($Output -match '(?i)unrecognized archive format|unsupported compression|liblzma|lzma') {
+        $hints.Add('The extractor cannot read .tar.xz. Install 7-Zip, or update Windows until "tar --version" reports liblzma.')
+    }
+    if ($Output -match '(?i)symlink|symbolic link|privilege') {
+        $hints.Add('A privileged operation failed, usually creating a symbolic link. Enable Windows developer mode or run the build from an elevated PowerShell session.')
+    }
+    if ($Output -match '(?i)permission denied|access is denied|used by another process') {
+        $hints.Add('A file could not be written. Exclude the build directory from real-time antivirus scanning and close anything holding the build output open.')
+    }
+    if ($Output -match '(?i)no space left|not enough space|disk full') {
+        $hints.Add('The build drive ran out of space during extraction.')
+    }
+    if ($ExtractRoot.Length -gt 120) {
+        $hints.Add("The extraction root is $($ExtractRoot.Length) characters long; deep paths break extraction on Windows. Re-run with a short work root, for example -WorkRoot C:\codex-build.")
+    }
+    if ($ExtractRoot -cmatch '[^\u0020-\u007E]') {
+        $hints.Add('The extraction root contains non-ASCII characters, which some extractors cannot resolve. Re-run with an ASCII-only work root, for example -WorkRoot C:\codex-build.')
+    }
+
+    return $hints.ToArray()
+}
+
+function New-ArchiveExtractionErrorMessage {
+    param(
+        [Parameter(Mandatory = $true)][string]$ToolPath,
+        [Parameter(Mandatory = $true)][int]$ExitCode,
+        [Parameter(Mandatory = $true)][AllowEmptyString()][string]$Output,
+        [Parameter(Mandatory = $true)][string]$ExtractRoot
+    )
+
+    $lines = New-Object System.Collections.Generic.List[string]
+    $lines.Add("Failed to extract Codex primary runtime archive with exit code $ExitCode (extractor: $ToolPath).")
+    if ([string]::IsNullOrWhiteSpace($Output)) {
+        $lines.Add('The extractor reported no output.')
+    }
+    else {
+        $lines.Add('Extractor output:')
+        $outputLines = @($Output -split "`r?`n" | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | Select-Object -Last 20)
+        foreach ($outputLine in $outputLines) {
+            $lines.Add("  $($outputLine.Trim())")
+        }
+    }
+
+    foreach ($hint in (Get-ArchiveExtractionHint -Output $Output -ExtractRoot $ExtractRoot)) {
+        $lines.Add("Hint: $hint")
+    }
+
+    return ($lines -join [System.Environment]::NewLine)
+}
+
+function Expand-CodexRuntimeArchive {
+    param(
+        [Parameter(Mandatory = $true)][string]$ArchivePath,
+        [Parameter(Mandatory = $true)][string]$ExtractRoot
+    )
+
+    $tool = Resolve-ArchiveExtractionTool
+    $inspectedText = if ($tool.inspected.Count -gt 0) { $tool.inspected -join '; ' } else { 'none' }
+    if ($tool.kind -eq 'none') {
+        throw "No extractor able to read the Codex primary runtime archive (.tar.xz) was found. Install 7-Zip, or use a tar build with xz support. Inspected: $inspectedText"
+    }
+
+    Write-BuildTrace "Extracting Codex primary runtime with $($tool.path)."
+
+    if ($tool.kind -eq 'sevenzip') {
+        # 7-Zip cannot stream .tar.xz in one pass, so decompress to a staged tar first.
+        $stageRoot = Join-Path (Split-Path -Parent $ExtractRoot) 'xz-stage'
+        if (Test-Path -LiteralPath $stageRoot) {
+            Remove-Item -LiteralPath $stageRoot -Recurse -Force
+        }
+        New-Item -ItemType Directory -Force -Path $stageRoot | Out-Null
+
+        try {
+            $decompressResult = Invoke-CapturedProcess -FilePath $tool.path -Arguments @('x', '-y', $ArchivePath, "-o$stageRoot")
+            if ($decompressResult.exitCode -ne 0) {
+                throw (New-ArchiveExtractionErrorMessage -ToolPath $tool.path -ExitCode $decompressResult.exitCode -Output $decompressResult.output -ExtractRoot $ExtractRoot)
+            }
+
+            $stagedTar = @(Get-ChildItem -LiteralPath $stageRoot -Filter '*.tar' -File) | Select-Object -First 1
+            if ($null -eq $stagedTar) {
+                throw "7-Zip did not produce a tar archive for the Codex primary runtime under $stageRoot."
+            }
+
+            $unpackResult = Invoke-CapturedProcess -FilePath $tool.path -Arguments @('x', '-y', $stagedTar.FullName, "-o$ExtractRoot")
+            if ($unpackResult.exitCode -ne 0) {
+                throw (New-ArchiveExtractionErrorMessage -ToolPath $tool.path -ExitCode $unpackResult.exitCode -Output $unpackResult.output -ExtractRoot $ExtractRoot)
+            }
+        }
+        finally {
+            if (Test-Path -LiteralPath $stageRoot) {
+                Remove-Item -LiteralPath $stageRoot -Recurse -Force -ErrorAction SilentlyContinue
+            }
+        }
+
+        return
+    }
+
+    $tarArguments = @()
+    if ($tool.forceLocal) {
+        # GNU tar otherwise reads the drive letter in "C:\..." as a remote host specification.
+        $tarArguments += '--force-local'
+    }
+    $tarArguments += @('-xf', $ArchivePath, '-C', $ExtractRoot)
+
+    $extractionResult = Invoke-CapturedProcess -FilePath $tool.path -Arguments $tarArguments
+    if ($extractionResult.exitCode -ne 0) {
+        throw (New-ArchiveExtractionErrorMessage -ToolPath $tool.path -ExitCode $extractionResult.exitCode -Output $extractionResult.output -ExtractRoot $ExtractRoot)
+    }
+}
+
 function Resolve-OfflineRuntimePluginMarketplaceRoot {
     param(
         [Parameter(Mandatory = $true)]$Config,
@@ -505,16 +782,8 @@ function Resolve-OfflineRuntimePluginMarketplaceRoot {
     }
     New-Item -ItemType Directory -Force -Path $extractRoot | Out-Null
 
-    $tarCommand = Get-Command tar -ErrorAction SilentlyContinue
-    if ($null -eq $tarCommand) {
-        throw 'tar was not found. It is required to extract the Codex primary runtime archive.'
-    }
-
     Write-BuildTrace "Extracting Codex primary runtime $version."
-    & $tarCommand.Source -xf $archivePath -C $extractRoot
-    if ($LASTEXITCODE -ne 0) {
-        throw "Failed to extract Codex primary runtime archive with tar exit code $LASTEXITCODE."
-    }
+    Expand-CodexRuntimeArchive -ArchivePath $archivePath -ExtractRoot $extractRoot
 
     if (-not (Test-Path -LiteralPath (Join-Path $marketplaceRoot '.agents\plugins\marketplace.json') -PathType Leaf)) {
         throw "Codex primary runtime marketplace was not found after extraction: $marketplaceRoot"

--- a/scripts/build-offline-package.ps1
+++ b/scripts/build-offline-package.ps1
@@ -547,7 +547,6 @@ function Resolve-ArchiveExtractionTool {
         $tarCandidates.Add([string]$pathTar.Source)
     }
 
-    $fallbackTarPath = ''
     foreach ($candidate in $tarCandidates) {
         if ([string]::IsNullOrWhiteSpace($candidate)) { continue }
         if ($seenPaths -contains $candidate.ToLowerInvariant()) { continue }
@@ -565,9 +564,6 @@ function Resolve-ArchiveExtractionTool {
             }
         }
 
-        if ([string]::IsNullOrWhiteSpace($fallbackTarPath) -and $capability.flavor -eq 'unknown') {
-            $fallbackTarPath = $candidate
-        }
     }
 
     foreach ($sevenZipCandidate in (Get-SevenZipCandidatePath)) {
@@ -580,15 +576,6 @@ function Resolve-ArchiveExtractionTool {
         return [ordered]@{
             kind = 'sevenzip'
             path = $sevenZipCandidate
-            forceLocal = $false
-            inspected = $inspected.ToArray()
-        }
-    }
-
-    if (-not [string]::IsNullOrWhiteSpace($fallbackTarPath)) {
-        return [ordered]@{
-            kind = 'tar'
-            path = $fallbackTarPath
             forceLocal = $false
             inspected = $inspected.ToArray()
         }

--- a/scripts/test/current-bundle-compatibility.test.cjs
+++ b/scripts/test/current-bundle-compatibility.test.cjs
@@ -3,6 +3,7 @@
 const assert = require("node:assert/strict");
 const { spawnSync } = require("node:child_process");
 const fs = require("node:fs");
+const os = require("node:os");
 const path = require("node:path");
 const test = require("node:test");
 
@@ -937,7 +938,7 @@ test("26.825 patcher keeps only current Settings and Worktree resolver shapes", 
 
 test("rg_adguard app-source cache requires the current resolver target", {
   skip: process.platform !== "win32",
-}, () => {
+}, (t) => {
   const helperStart = buildScriptSource.indexOf("function Get-OptionalProperty {");
   const helperEnd = buildScriptSource.indexOf("\n\n$scriptRoot =", helperStart);
   assert.notEqual(helperStart, -1, "Get-OptionalProperty is missing");
@@ -982,10 +983,22 @@ test("rg_adguard app-source cache requires the current resolver target", {
     `$installedStale = $installedCached | ConvertTo-Json | ConvertFrom-Json; $installedStale.version = '26.820.7780.0'`,
     "[ordered]@{matching=(Test-AppSourceCacheCompatible -SourceMetadata $cached -Config $config -ResolvedSource $resolved);versionMismatch=(Test-AppSourceCacheCompatible -SourceMetadata $staleVersion -Config $config -ResolvedSource $resolved);shaMismatch=(Test-AppSourceCacheCompatible -SourceMetadata $wrongSha1 -Config $config -ResolvedSource $resolved);missingSha1=(Test-AppSourceCacheCompatible -SourceMetadata $missingSha1 -Config $config -ResolvedSource $resolved);sourceModeMismatch=(Test-AppSourceCacheCompatible -SourceMetadata $wrongMode -Config $config -ResolvedSource $resolved);packageFamilyMismatch=(Test-AppSourceCacheCompatible -SourceMetadata $wrongFamily -Config $config -ResolvedSource $resolved);installedMatching=(Test-AppSourceCacheCompatible -SourceMetadata $installedCached -Config $installedConfig -ResolvedSource $installedTarget);installedVersionMismatch=(Test-AppSourceCacheCompatible -SourceMetadata $installedStale -Config $installedConfig -ResolvedSource $installedTarget)} | ConvertTo-Json -Compress",
   ].join("\n");
-  const result = spawnSync("powershell.exe", ["-NoProfile", "-Command", command], {
-    encoding: "utf8",
-  });
-  assert.equal(result.status, 0, result.stderr || result.stdout);
+  // The helper block is far past the Windows command-line limit, so -Command cannot carry it.
+  const scriptRoot = fs.mkdtempSync(path.join(os.tmpdir(), "codex-app-source-cache-"));
+  const scriptPath = path.join(scriptRoot, "app-source-cache.ps1");
+  fs.writeFileSync(scriptPath, command, "utf8");
+  t.after(() => fs.rmSync(scriptRoot, { recursive: true, force: true }));
+
+  const result = spawnSync(
+    "powershell.exe",
+    ["-NoProfile", "-ExecutionPolicy", "Bypass", "-File", scriptPath],
+    { encoding: "utf8" },
+  );
+  assert.equal(
+    result.status,
+    0,
+    result.error ? result.error.message : result.stderr || result.stdout,
+  );
   const values = JSON.parse(result.stdout.trim());
   assert.deepEqual(values, {
     matching: true,

--- a/scripts/test/primary-runtime-archive-extraction.test.cjs
+++ b/scripts/test/primary-runtime-archive-extraction.test.cjs
@@ -1,0 +1,108 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const test = require("node:test");
+
+const repoRoot = path.resolve(__dirname, "../..");
+const buildScriptSource = fs.readFileSync(
+  path.join(repoRoot, "scripts", "build-offline-package.ps1"),
+  "utf8",
+);
+
+function functionSource(name) {
+  const start = buildScriptSource.indexOf(`function ${name} {`);
+  assert.notEqual(start, -1, `function ${name} is missing`);
+  const end = buildScriptSource.indexOf("\nfunction ", start + 1);
+  assert.notEqual(end, -1, `function ${name} has no successor to bound it`);
+  return buildScriptSource.slice(start, end);
+}
+
+test("primary runtime extraction prefers the Windows tar over an MSYS tar on PATH", () => {
+  const resolver = functionSource("Resolve-ArchiveExtractionTool");
+
+  assert.match(resolver, /\$env:SystemRoot 'System32\\tar\.exe'/);
+  assert.ok(
+    resolver.indexOf("System32\\tar.exe") <
+      resolver.indexOf("Get-Command 'tar' -CommandType Application"),
+    "the bundled Windows tar must be inspected before any tar found on PATH",
+  );
+});
+
+test("primary runtime extraction only uses a tar that can read .tar.xz", () => {
+  const capability = functionSource("Get-ArchiveToolCapability");
+
+  // Windows ships bsdtar builds without liblzma, which cannot open the .tar.xz runtime archive.
+  assert.match(capability, /bsdtar\|libarchive/);
+  assert.match(capability, /supportsXz = \(\$versionText -match '\(\?i\)liblzma'\)/);
+  // GNU tar delegates xz to a separate binary.
+  assert.match(capability, /GNU tar/);
+  assert.match(capability, /Get-Command 'xz' -CommandType Application/);
+
+  const resolver = functionSource("Resolve-ArchiveExtractionTool");
+  assert.match(resolver, /if \(\$capability\.supportsXz\) \{/);
+});
+
+test("primary runtime extraction falls back to 7-Zip when no tar can read xz", () => {
+  const sevenZip = functionSource("Get-SevenZipCandidatePath");
+  assert.match(sevenZip, /'7z', '7zz', '7za'/);
+  assert.match(sevenZip, /'7-Zip\\7z\.exe'/);
+
+  const resolver = functionSource("Resolve-ArchiveExtractionTool");
+  assert.ok(
+    resolver.indexOf("Get-SevenZipCandidatePath") >
+      resolver.indexOf("if ($capability.supportsXz) {"),
+    "7-Zip is only a fallback for tar builds without xz support",
+  );
+  assert.match(resolver, /kind = 'sevenzip'/);
+
+  const expand = functionSource("Expand-CodexRuntimeArchive");
+  // 7-Zip needs two passes: .tar.xz to a staged .tar, then the tar tree.
+  assert.match(expand, /Get-ChildItem -LiteralPath \$stageRoot -Filter '\*\.tar' -File/);
+  assert.match(expand, /Remove-Item -LiteralPath \$stageRoot -Recurse -Force -ErrorAction SilentlyContinue/);
+});
+
+test("primary runtime extraction keeps GNU tar from reading a drive letter as a remote host", () => {
+  const expand = functionSource("Expand-CodexRuntimeArchive");
+  assert.match(expand, /if \(\$tool\.forceLocal\) \{[\s\S]*?\$tarArguments \+= '--force-local'/);
+
+  const resolver = functionSource("Resolve-ArchiveExtractionTool");
+  assert.match(resolver, /forceLocal = \(\$capability\.flavor -eq 'gnutar'\)/);
+});
+
+test("primary runtime extraction failures report the extractor output and actionable hints", () => {
+  const message = functionSource("New-ArchiveExtractionErrorMessage");
+  assert.match(message, /Failed to extract Codex primary runtime archive with exit code \$ExitCode \(extractor: \$ToolPath\)/);
+  assert.match(message, /Extractor output:/);
+  assert.match(message, /Get-ArchiveExtractionHint -Output \$Output -ExtractRoot \$ExtractRoot/);
+
+  const hints = functionSource("Get-ArchiveExtractionHint");
+  assert.match(hints, /unrecognized archive format\|unsupported compression\|liblzma\|lzma/);
+  assert.match(hints, /symlink\|symbolic link\|privilege/);
+  assert.match(hints, /permission denied\|access is denied\|used by another process/);
+  assert.match(hints, /no space left\|not enough space\|disk full/);
+  assert.match(hints, /\$ExtractRoot\.Length -gt 120/);
+  assert.match(hints, /\$ExtractRoot -cmatch '\[\^\\u0020-\\u007E\]'/);
+
+  // The archive path itself ends in .tar.xz, so the xz hint must not match on the file name alone.
+  assert.doesNotMatch(hints, /\(\?i\)[^']*\|xz\|/);
+
+  const expand = functionSource("Expand-CodexRuntimeArchive");
+  assert.match(expand, /No extractor able to read the Codex primary runtime archive/);
+  assert.match(expand, /Inspected: \$inspectedText/);
+});
+
+test("primary runtime extraction captures both extractor streams instead of dropping them", () => {
+  const captured = functionSource("Invoke-CapturedProcess");
+  assert.match(captured, /-RedirectStandardOutput \$stdoutPath -RedirectStandardError \$stderrPath/);
+  assert.match(captured, /exitCode = \[int\]\$process\.ExitCode/);
+
+  // The old call site swallowed tar's diagnostics and only surfaced $LASTEXITCODE.
+  assert.doesNotMatch(buildScriptSource, /tar exit code \$LASTEXITCODE/);
+  assert.doesNotMatch(buildScriptSource, /& \$tarCommand\.Source -xf/);
+  assert.match(
+    buildScriptSource,
+    /Expand-CodexRuntimeArchive -ArchivePath \$archivePath -ExtractRoot \$extractRoot/,
+  );
+});

--- a/scripts/test/primary-runtime-archive-extraction.test.cjs
+++ b/scripts/test/primary-runtime-archive-extraction.test.cjs
@@ -1,7 +1,9 @@
 "use strict";
 
 const assert = require("node:assert/strict");
+const { spawnSync } = require("node:child_process");
 const fs = require("node:fs");
+const os = require("node:os");
 const path = require("node:path");
 const test = require("node:test");
 
@@ -18,6 +20,72 @@ function functionSource(name) {
   assert.notEqual(end, -1, `function ${name} has no successor to bound it`);
   return buildScriptSource.slice(start, end);
 }
+
+function resolveToolWithStubs(t, capability, sevenZipCandidates = []) {
+  const scriptRoot = fs.mkdtempSync(path.join(os.tmpdir(), "codex-archive-tool-"));
+  const scriptPath = path.join(scriptRoot, "resolve-archive-tool.ps1");
+  t.after(() => fs.rmSync(scriptRoot, { recursive: true, force: true }));
+
+  const script = [
+    functionSource("Resolve-ArchiveExtractionTool"),
+    "function Get-Command { return $null }",
+    "function Test-Path { return $true }",
+    `function Get-ArchiveToolCapability { [ordered]@{ flavor = '${capability.flavor}'; supportsXz = $${capability.supportsXz ? "true" : "false"}; version = 'stub' } }`,
+    `function Get-SevenZipCandidatePath { @(${sevenZipCandidates.map((candidate) => `'${candidate}'`).join(", ")}) }`,
+    "$env:SystemRoot = 'C:\\Windows'",
+    "Resolve-ArchiveExtractionTool | ConvertTo-Json -Compress",
+  ].join("\n");
+  fs.writeFileSync(scriptPath, script, "utf8");
+
+  const result = spawnSync(
+    "powershell.exe",
+    ["-NoProfile", "-ExecutionPolicy", "Bypass", "-File", scriptPath],
+    { encoding: "utf8" },
+  );
+  assert.equal(
+    result.status,
+    0,
+    result.error ? result.error.message : result.stderr || result.stdout,
+  );
+  return JSON.parse(result.stdout.trim());
+}
+
+test("primary runtime extraction rejects an unverified tar when no 7-Zip is available", {
+  skip: process.platform !== "win32",
+}, (t) => {
+  const tool = resolveToolWithStubs(t, {
+    flavor: "unknown",
+    supportsXz: false,
+  });
+
+  assert.equal(tool.kind, "none");
+  assert.equal(tool.path, "");
+});
+
+test("primary runtime extraction uses 7-Zip when tar support is unverified", {
+  skip: process.platform !== "win32",
+}, (t) => {
+  const tool = resolveToolWithStubs(
+    t,
+    { flavor: "unknown", supportsXz: false },
+    ["C:\\Tools\\7z.exe"],
+  );
+
+  assert.equal(tool.kind, "sevenzip");
+  assert.equal(tool.path, "C:\\Tools\\7z.exe");
+});
+
+test("primary runtime extraction enables force-local for a verified GNU tar", {
+  skip: process.platform !== "win32",
+}, (t) => {
+  const tool = resolveToolWithStubs(t, {
+    flavor: "gnutar",
+    supportsXz: true,
+  });
+
+  assert.equal(tool.kind, "tar");
+  assert.equal(tool.forceLocal, true);
+});
 
 test("primary runtime extraction prefers the Windows tar over an MSYS tar on PATH", () => {
   const resolver = functionSource("Resolve-ArchiveExtractionTool");


### PR DESCRIPTION
修复 #108：本地构建在解压 primary runtime 插件包时报 `Failed to extract Codex primary runtime archive with tar exit code 1`。

## 根因

归档的 SHA256 在解压前已校验，所以失败与下载内容无关，问题在解压器：

1. **没有确认 tar 是否支持 xz。** primary runtime 是 `.tar.xz`。Windows 自带的 `%SystemRoot%\System32\tar.exe`（bsdtar）在部分版本上只链接了 zlib（`tar --version` 无 `liblzma`），根本打不开 xz，退出码 1。`windows-latest` runner 上的 tar 带 `liblzma`，因此 CI 一直是绿的，本地却失败。
2. **`Get-Command tar` 可能命中 MSYS/Cygwin 的 GNU tar**（Git for Windows、MSYS2 排在 `System32` 前面），它把 `C:\...` 的盘符当作远程主机名，且 `.tar.xz` 还需要单独的 `xz` 可执行文件。
3. **tar 的诊断信息被丢弃。** 旧代码只抛 `$LASTEXITCODE`，导致上述情况与其它同样退出码 1 的 Windows 故障（符号链接权限、杀软占用、磁盘满、工作目录过深或含非 ASCII 字符）无法区分。

## 改动落点

只改 `scripts/build-offline-package.ps1` 中的 primary runtime 插件步骤，未触及 Gateway、桌面补丁、安装器与打包产物；解压后的 `marketplace.json` 校验保持不变，部分解压仍然失败关闭。

- `Resolve-ArchiveExtractionTool`：先看 `%SystemRoot%\System32\tar.exe`，再看 PATH 上的 `tar`；每个候选用 `--version` 探测，bsdtar 必须报告 `liblzma`，GNU tar 必须存在 `xz` 且以 `--force-local` 调用。
- 没有合格的 tar 时回退到 7-Zip（PATH 上的 `7z`/`7zz`/`7za`，或标准安装路径的 `7-Zip\7z.exe`），先解出临时 `.tar` 再展开，临时目录必定清理。
- 探测不出 xz 支持的 tar **不做兜底**：没有已验证的 tar 也没有 7-Zip 时确定返回 `kind = none`，构建失败关闭并列出检查过的全部候选（`5ff65bf`）。
- `Invoke-CapturedProcess` 捕获 stdout/stderr，`New-ArchiveExtractionErrorMessage` 把最后 20 行真实输出与针对性提示一并抛出（缺 xz 支持、符号链接权限、文件被占用/权限拒绝、磁盘不足、解压根目录超 120 字符或含非 ASCII 字符）。

另外，`scripts/test/current-bundle-compatibility.test.cjs` 原本把整块 helper 通过 `powershell.exe -Command` 传入，长度本就逼近 Windows 32,767 字符命令行上限，新增 helper 后达到 40,275 字符导致进程无法启动、测试只报 `null !== 0`。现改为写入临时 `.ps1` 并以 `-File` 执行，并在进程起不来时输出 `result.error`。

## 变更文件

- `scripts/build-offline-package.ps1` — 解压器选择、输出捕获与失败诊断
- `scripts/test/primary-runtime-archive-extraction.test.cjs` — 新增回归测试（源码断言 + 直接执行 resolver 的行为测试）
- `scripts/test/current-bundle-compatibility.test.cjs` — 改用脚本文件调用 PowerShell
- `docs/issue-108-primary-runtime-extract-failure.md` — 根因与修复记录
- `README.md`、`CHANGELOG.md` — 构建前置条件与变更说明

## 验证

- `node --test scripts/test/primary-runtime-archive-extraction.test.cjs`：源码断言 6 条回到旧实现全部失败；新增的 3 条行为测试（unknown tar 拒绝、7-Zip 回退、GNU tar `forceLocal`）在删掉兜底前稳定失败于 `tar !== none`。
- `node --test scripts/test/*.test.cjs`：122 通过、2 失败、6 跳过 —— 失败与跳过的都是需要 Windows PowerShell 的用例，本次改动所用的 Linux 沙箱没有它，与本改动无关。
- Windows-only 用例用 PowerShell 7.4 顶替实跑：`current-bundle-compatibility` 53/53 通过；`primary-runtime-archive-extraction` 9/9 通过（`Join-Path 'C:\Windows'` 在 Linux 上没有 `C:` PSDrive，本地替身需换成有效路径，真实 Windows 无此限制）。
- PowerShell AST 解析 `scripts/build-offline-package.ps1` 无语法错误（与 CI 的 `Test-PowerShellSyntax` 同一检查）。
- PowerShell 7.4 + 桩解压器实跑四条路径：无 `liblzma` 的 bsdtar → 选中 7-Zip、两步解压成功并清理暂存目录；带 `liblzma` 的 bsdtar 失败 → 原始输出与对应提示进入报错；GNU tar → 带上 `--force-local`；无解压器 → 失败关闭并列出候选。
- CI 全绿两轮：[run 33839752722](https://github.com/lusipad/unofficial-codex-app-offline/actions/runs/33839752722)（head `8d688e9`）与 [run 33902977194](https://github.com/lusipad/unofficial-codex-app-offline/actions/runs/33902977194)（head `5ff65bf`）。完整构建用真实 `.tar.xz` 走通新解压路径，build metadata 中 `primaryRuntime.marketplaceRoot` 正常生成，`Verify offline bundle` 通过。

## 仍未覆盖的风险

- 真实 7-Zip 二进制路径不会被 CI 覆盖（CI 总能解析到合格的 `tar.exe`），仅由桩测试保障。
- 路径过深与非 ASCII 只给出提示，不自动修正；仍需用 `-WorkRoot` 指向短的纯 ASCII 目录。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YHgK92TQ2ap6EQhHtnne9f